### PR TITLE
fix list validation

### DIFF
--- a/FilterComplexCore.js
+++ b/FilterComplexCore.js
@@ -287,7 +287,7 @@ module.exports = class FilterComplexCore extends ABComponent {
    listValid(value, rule, compareValue) {
       var result = false;
 
-      compareValue = compareValue.toLowerCase();
+      // compareValue = compareValue.toLowerCase();
 
       if (!Array.isArray(compareValue)) compareValue = [compareValue];
 


### PR DESCRIPTION
This was causing problem cloning a Datacollection with list filters. `compareValue` was changed to lower case which then did not match `Value` which was upper case.

Fixes #73 and digi-serve/well_app#11