### PR TITLE
migrate v1 changes in to v2 for filteredClones of data collections

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -2355,10 +2355,9 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       // check to see that filters are set (this is sometimes helpful to select the first record without doing so at the data collection level)
       if (filters?.rules?.length) {
          if (obj.settings.objectWorkspace.filterConditions?.rules?.length) {
-            obj.settings.objectWorkspace.filterConditions = {
-               glue: "and",
-               rules: [obj.settings.objectWorkspace.filterConditions, filters],
-            };
+            obj.settings.objectWorkspace.filterConditions.rules = obj.settings.objectWorkspace.filterConditions.rules.concat(
+               filters.rules
+            );
          } else {
             obj.settings.objectWorkspace.filterConditions = filters;
          }


### PR DESCRIPTION
This change needed to be moved to v2 so things like our Record Rules with additional filters can properly pass the filter conditions.