### PR TITLE
clone dc before returning it

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -2362,7 +2362,8 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             obj.settings.objectWorkspace.filterConditions = filters;
          }
       }
-      return this.clone(obj); // new ABViewDataCollection(settings, this.application, this.parent);
+      let clonedDC = this.clone(obj);
+      return clonedDC; // new ABViewDataCollection(settings, this.application, this.parent);
    }
 
    //


### PR DESCRIPTION
cursor was not set on filtered clones of data collections until it was too late...seeing if this method helps.