### PR TITLE
Check field exists before setting result

### DIFF
--- a/dataFields/ABFieldCore.js
+++ b/dataFields/ABFieldCore.js
@@ -312,9 +312,9 @@ module.exports = class ABFieldCore extends ABMLClass {
       const propName = `${this.alias || this.object.name}.${this.columnName}`;
 
       let result = "";
-      if (rowData[this.columnName] != null) {
+      if (rowData?.[this.columnName] != null) {
          result = rowData[this.columnName];
-      } else if (rowData[propName] != null) {
+      } else if (rowData?.[propName] != null) {
          result = rowData[propName];
       }
 


### PR DESCRIPTION
When clearing a cursor we the rowData is null, thus all checks on rowData for values will fail.