### PR TITLE
Jh/interface warnings

### DIFF
--- a/views/ABViewCarouselCore.js
+++ b/views/ABViewCarouselCore.js
@@ -24,6 +24,22 @@ const ABViewDefaults = {
    labelKey: "Carousel", // {string} the multilingual label key for the class label
 };
 
+function parseIntOrDefault(_this, key) {
+   if (typeof _this.settings[key] != "undefined") {
+      _this.settings[key] = parseInt(_this.settings[key]);
+   } else {
+      _this.settings[key] = ABViewCarouselPropertyComponentDefaults[key];
+   }
+}
+
+function parseOrDefault(_this, key) {
+   try {
+      _this.settings[key] = JSON.parse(_this.settings[key]);
+   } catch (e) {
+      _this.settings[key] = ABViewCarouselPropertyComponentDefaults[key];
+   }
+}
+
 module.exports = class ABViewCarouselCore extends ABViewWidget {
    constructor(values, application, parent, defaultValues) {
       super(values, application, parent, defaultValues || ABViewDefaults);
@@ -50,46 +66,22 @@ module.exports = class ABViewCarouselCore extends ABViewWidget {
    fromValues(values) {
       super.fromValues(values);
 
+      debugger;
+
       // convert from "0" => 0
-      if (typeof this.settings.width != "undefined") {
-         this.settings.width = parseInt(this.settings.width);
-      } else {
-         this.settings.width = ABViewCarouselPropertyComponentDefaults.width;
-      }
-      if (typeof this.settings.height != "undefined") {
-         this.settings.height = parseInt(this.settings.height);
-      } else {
-         this.settings.height = ABViewCarouselPropertyComponentDefaults.height;
-      }
-      try {
-         this.settings.showLabel = JSON.parse(this.settings.showLabel);
-      } catch (e) {
-         this.settings.showLabel =
-            ABViewCarouselPropertyComponentDefaults.showLabel;
-      }
-      try {
-         this.settings.hideItem = JSON.parse(this.settings.hideItem);
-      } catch (e) {
-         this.settings.hideItem =
-            ABViewCarouselPropertyComponentDefaults.hideItem;
-      }
-      try {
-         this.settings.hideButton = JSON.parse(this.settings.hideButton);
-      } catch (e) {
-         this.settings.hideButton =
-            ABViewCarouselPropertyComponentDefaults.hideButton;
-      }
+      parseIntOrDefault(this, "width");
+      parseIntOrDefault(this, "height");
+
+      // json
+      parseOrDefault(this, "showLabel");
+      parseOrDefault(this, "hideItem");
+      parseOrDefault(this, "hideButton");
+
       this.settings.navigationType =
          this.settings.navigationType ||
          ABViewCarouselPropertyComponentDefaults.navigationType;
-      try {
-         this.settings.filterByCursor = JSON.parse(
-            this.settings.filterByCursor
-         );
-      } catch (e) {
-         this.settings.filterByCursor =
-            ABViewCarouselPropertyComponentDefaults.filterByCursor;
-      }
+
+      parseOrDefault(this, "filterByCursor");
    }
 
    /**
@@ -107,6 +99,6 @@ module.exports = class ABViewCarouselCore extends ABViewWidget {
       let obj = dc.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.field)[0];
+      return obj.fieldByID(this.settings.field);
    }
 };

--- a/views/ABViewCarouselCore.js
+++ b/views/ABViewCarouselCore.js
@@ -66,8 +66,6 @@ module.exports = class ABViewCarouselCore extends ABViewWidget {
    fromValues(values) {
       super.fromValues(values);
 
-      debugger;
-
       // convert from "0" => 0
       parseIntOrDefault(this, "width");
       parseIntOrDefault(this, "height");

--- a/views/ABViewChartCore.js
+++ b/views/ABViewChartCore.js
@@ -90,7 +90,6 @@ module.exports = class ABViewChartCore extends ABViewContainer {
       );
 
       this.translate(this, this, ["chartLabel"]);
-      this.refreshData();
    }
 
    /**
@@ -98,13 +97,10 @@ module.exports = class ABViewChartCore extends ABViewContainer {
     * return the list of components available on this view to display in the editor.
     */
    componentList() {
-      const viewsToAllow = ["label", "pie", "bar", "line", "area"],
-         allComponents = this.application.viewAll(); // ABViewManager.allViews();
-
-      const ret = allComponents.filter((c) => {
+      const viewsToAllow = ["label", "pie", "bar", "line", "area"];
+      return this.application.viewAll((c) => {
          return viewsToAllow.indexOf(c.common().key) > -1;
       });
-      return ret;
    }
 
    labelField() {
@@ -114,7 +110,7 @@ module.exports = class ABViewChartCore extends ABViewContainer {
       const obj = dc.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.columnLabel)[0];
+      return obj.fieldByID(this.settings.columnLabel);
    }
 
    valueField() {
@@ -124,7 +120,7 @@ module.exports = class ABViewChartCore extends ABViewContainer {
       const obj = dc.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.columnValue)[0];
+      return obj.fieldByID(this.settings.columnValue);
    }
 
    valueField2() {
@@ -134,6 +130,6 @@ module.exports = class ABViewChartCore extends ABViewContainer {
       const obj = dc.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.columnValue2)[0];
+      return obj.fieldByID(this.settings.columnValue2);
    }
 };

--- a/views/ABViewCommentCore.js
+++ b/views/ABViewCommentCore.js
@@ -83,7 +83,7 @@ module.exports = class ABViewCommentCore extends ABViewWidget {
       var obj = dv.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.columnUser)[0];
+      return obj.fieldByID(this.settings.columnUser);
    }
 
    getCommentField() {
@@ -93,7 +93,7 @@ module.exports = class ABViewCommentCore extends ABViewWidget {
       var obj = dv.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.columnComment)[0];
+      return obj.fieldByID(this.settings.columnComment);
    }
 
    getDateField() {
@@ -103,10 +103,14 @@ module.exports = class ABViewCommentCore extends ABViewWidget {
       var obj = dv.datasource;
       if (!obj) return null;
 
-      return obj.fields((f) => f.id == this.settings.columnDate)[0];
+      return obj.fieldByID(this.settings.columnDate);
    }
 
    getUserData() {
+      let UserImageField = this.AB.objectUser().fieldByID(
+         "6383ce19-b344-44ee-87e6-decced7361f8"
+      );
+
       var userObject = this.getUsers();
       var userList = [];
 
@@ -115,7 +119,7 @@ module.exports = class ABViewCommentCore extends ABViewWidget {
       userObject.forEach((item, index) => {
          var imageURL = "";
          if (item.image) {
-            imageURL = "/opsportal/image/UserProfile/" + item.image;
+            imageURL = UserImageField.urlImage(item.image);
          }
          var user = { id: index + 1, value: item.value, image: imageURL };
          userList.push(user);
@@ -126,10 +130,6 @@ module.exports = class ABViewCommentCore extends ABViewWidget {
    model() {
       let dv = this.datacollection;
       if (!dv) return null; // TODO: refactor in v2
-
-      // get ABObject
-      let obj = dv.datasource;
-      if (obj == null) return null; // TODO: refactor in v2
 
       // get ABModel
       let model = dv.model; // already notified

--- a/views/ABViewConditionalContainerCore.js
+++ b/views/ABViewConditionalContainerCore.js
@@ -62,4 +62,13 @@ module.exports = class ABViewConditionalContainerCore extends ABViewContainer {
    static defaultValues() {
       return ABViewPropertyDefaults;
    }
+
+   /**
+    * @method componentList
+    * return the list of components available on this view to display in the editor.
+    * For a Conditional Container, we don't allow any other items to be placed on it.
+    */
+   componentList() {
+      return [];
+   }
 };

--- a/views/ABViewConnectDataFilterCore.js
+++ b/views/ABViewConnectDataFilterCore.js
@@ -29,21 +29,10 @@ module.exports = class ABViewConnectDataFilterCore extends ABViewWidget {
    ///
 
    /**
-    * @method fromValues()
-    *
-    * initialze this object with the given set of values.
-    * @param {obj} values
-    */
-   fromValues(values) {
-      super.fromValues(values);
-   }
-
-   /**
     * @method componentList
     * return the list of components available on this view to display in the editor.
     */
    componentList() {
       return [];
    }
-
 };

--- a/views/ABViewContainerCore.js
+++ b/views/ABViewContainerCore.js
@@ -22,6 +22,8 @@ const ABViewDefaults = {
 const ABPropertyComponentDefaults = {
    columns: 1,
    gravity: 1,
+   movable: true,
+   removable: true,
 };
 
 module.exports = class ABViewContainerCore extends ABView {
@@ -66,13 +68,13 @@ module.exports = class ABViewContainerCore extends ABView {
       if (this.settings.removable != null) {
          this.settings.removable = JSON.parse(this.settings.removable); // convert to boolean
       } else {
-         this.settings.removable = true;
+         this.settings.removable = ABPropertyComponentDefaults.removable;
       }
 
       if (this.settings.movable != null) {
          this.settings.movable = JSON.parse(this.settings.movable); // convert to boolean
       } else {
-         this.settings.movable = true;
+         this.settings.movable = ABPropertyComponentDefaults.movable;
       }
    }
 

--- a/views/ABViewCore.js
+++ b/views/ABViewCore.js
@@ -59,19 +59,19 @@ module.exports = class ABViewCore extends ABMLClass {
 
    /**
     * @method newInstance()
-    * return a new instance of this ABView.
+    * return a new instance of this ABView.  Most likely called from interfaces
+    * that create new UI elements like the ABDesigner.
     * @param {ABApplication} application  	: the root ABApplication this view is under
     * @param {ABView/ABApplication} parent	: the parent object of this ABView.
     * @return {ABView}
     */
    static newInstance(application, parent) {
-      console.error("!!! where is this being called???");
       // return a new instance from ABViewManager:
       return application.viewNew(
          { key: this.common().key },
          application,
          parent
-      ); // ABViewManager.newView({ key: this.common().key }, application, parent);
+      );
    }
 
    viewKey() {
@@ -237,9 +237,7 @@ module.exports = class ABViewCore extends ABMLClass {
 
    /**
     * @method allParents()
-    *
-    * return an flatten array of all the ABViews parents
-    *
+    * return a flattened array of all the ABViews parents
     * @return {array}      array of ABViews
     */
    allParents() {
@@ -466,7 +464,9 @@ module.exports = class ABViewCore extends ABMLClass {
             });
          } else {
             // These views shouldn't matter if they don't have a datacollection.
-            if (["page", "viewcontainer"].indexOf(this.key) == -1) {
+            if (
+               ["label", "page", "tab", "viewcontainer"].indexOf(this.key) == -1
+            ) {
                console.warn(
                   `TODO: figure out which ABView* require a .dataviewID: ${this.key}?`
                );

--- a/views/ABViewCore.js
+++ b/views/ABViewCore.js
@@ -465,7 +465,9 @@ module.exports = class ABViewCore extends ABMLClass {
          } else {
             // These views shouldn't matter if they don't have a datacollection.
             if (
-               ["label", "page", "tab", "viewcontainer"].indexOf(this.key) == -1
+               ["button", "label", "page", "tab", "viewcontainer"].indexOf(
+                  this.key
+               ) == -1
             ) {
                console.warn(
                   `TODO: figure out which ABView* require a .dataviewID: ${this.key}?`

--- a/views/ABViewDataFilterCore.js
+++ b/views/ABViewDataFilterCore.js
@@ -11,7 +11,7 @@ const ABViewDataFilterPropertyComponentDefaults = {
 const ABViewDefaults = {
    key: "data-filter", // {string} unique key for this view
    icon: "filter", // {string} fa-[icon] reference for this view
-   labelKey: "ab.components.datafitler", // {string} the multilingual label key for the class label
+   labelKey: "Data Filter", // {string} the multilingual label key for the class label
 };
 
 module.exports = class ABViewDataFilterCore extends ABViewWidget {

--- a/views/ABViewDetailCheckboxCore.js
+++ b/views/ABViewDetailCheckboxCore.js
@@ -30,12 +30,4 @@ module.exports = class ABViewDetailCheckboxCore extends ABViewDetailItem {
    static defaultValues() {
       return ABViewDetailCheckboxPropertyComponentDefaults;
    }
-
-   /*
-    * @method componentList
-    * return the list of components available on this view to display in the editor.
-    */
-   componentList() {
-      return [];
-   }
 };

--- a/views/ABViewDetailCustomCore.js
+++ b/views/ABViewDetailCustomCore.js
@@ -30,12 +30,4 @@ module.exports = class ABViewDetailCustomCore extends ABViewDetailItem {
    static defaultValues() {
       return ABViewDetailCustomPropertyComponentDefaults;
    }
-
-   /*
-    * @method componentList
-    * return the list of components available on this view to display in the editor.
-    */
-   componentList() {
-      return [];
-   }
 };

--- a/views/ABViewDetailImageCore.js
+++ b/views/ABViewDetailImageCore.js
@@ -56,12 +56,4 @@ module.exports = class ABViewDetailImageCore extends ABViewDetailItem {
          this.settings.width ?? ABViewDetailImagePropertyComponentDefaults.width
       );
    }
-
-   /**
-    * @method componentList
-    * return the list of components available on this view to display in the editor.
-    */
-   componentList() {
-      return [];
-   }
 };

--- a/views/ABViewDetailItemCore.js
+++ b/views/ABViewDetailItemCore.js
@@ -60,4 +60,22 @@ module.exports = class ABViewDetailItemCore extends ABViewWidget {
       if (currData) return currData[field.columnName];
       else return null;
    }
+
+   /**
+    * @method componentList
+    * return the list of components available on this view to display in the editor.
+    */
+   componentList() {
+      return [];
+   }
+
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      return null;
+   }
 };

--- a/views/ABViewDetailSelectivityCore.js
+++ b/views/ABViewDetailSelectivityCore.js
@@ -46,12 +46,4 @@ module.exports = class ABViewDetailSelectivityCore extends ABViewDetailItem {
          this.settings.height ?? ABViewDetailPropertyComponentDefaults.height
       );
    }
-
-   /**
-    * @method componentList
-    * return the list of components available on this view to display in the editor.
-    */
-   componentList() {
-      return [];
-   }
 };

--- a/views/ABViewDetailTextCore.js
+++ b/views/ABViewDetailTextCore.js
@@ -52,12 +52,4 @@ module.exports = class ABViewDetailTextCore extends ABViewDetailItem {
             ABViewDetailTextPropertyComponentDefaults.height
       );
    }
-
-   /**
-    * @method componentList
-    * return the list of components available on this view to display in the editor.
-    */
-   componentList() {
-      return [];
-   }
 };

--- a/views/ABViewDetailTreeCore.js
+++ b/views/ABViewDetailTreeCore.js
@@ -30,12 +30,4 @@ module.exports = class ABViewDetailTextCore extends ABViewDetailItem {
    static defaultValues() {
       return ABViewDetailPropertyComponentDefaults;
    }
-
-   /**
-    * @method componentList
-    * return the list of components available on this view to display in the editor.
-    */
-   componentList() {
-      return [];
-   }
 };

--- a/views/ABViewDocxBuilderCore.js
+++ b/views/ABViewDocxBuilderCore.js
@@ -70,23 +70,10 @@ module.exports = class ABViewDocxBuilderCore extends ABViewWidget {
    uploadUrl() {
       // TODO: Convert this to use ABFactory.urlFileUpload() or a ABFieldFile
       // to get the URL:
-      console.warn(
-         new Error(
-            "TODO: convert ABViewDocxBuilderCore.uploadUrl() to use common url code."
-         )
-      );
-      // let actionKey =
-      //    "opstool.AB_" + this.application.name.replace("_", "") + ".view";
-
-      // return (
-      //    "/" +
-      //    ["opsportal", "file", this.application.name, actionKey, "1"].join("/")
-      // );
 
       const object = this.datacollection.datasource;
 
-      // NOTE: file-upload API needs to have the id of a field.
-      // TODO
+      // NOTE: file-upload API needs to have the id of ANY field.
       const field = object ? object.fields()[0] : null;
 
       return `/file/upload/${object?.id}/${field?.id}/1`;

--- a/views/ABViewFormButtonCore.js
+++ b/views/ABViewFormButtonCore.js
@@ -62,6 +62,16 @@ module.exports = class ABViewFormButtonCore extends ABView {
       return result;
    }
 
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      return null;
+   }
+
    fromValues(values) {
       super.fromValues(values);
 

--- a/views/ABViewFormItemCore.js
+++ b/views/ABViewFormItemCore.js
@@ -14,6 +14,22 @@ module.exports = class ABViewFormComponentCore extends ABView {
       return ABViewFormFieldPropertyComponentDefaults;
    }
 
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      let form = this.parentFormComponent();
+      if (form == null) return null;
+
+      let datacollection = form.datacollection;
+      if (datacollection == null) return null;
+
+      return datacollection;
+   }
+
    field() {
       if (this.settings.objectId) {
          let object = this.AB.objectByID(this.settings.objectId);
@@ -41,4 +57,3 @@ module.exports = class ABViewFormComponentCore extends ABView {
       }
    }
 };
-

--- a/views/ABViewFormTextboxCore.js
+++ b/views/ABViewFormTextboxCore.js
@@ -36,4 +36,3 @@ module.exports = class ABViewFormTextboxCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewGridCore.js
+++ b/views/ABViewGridCore.js
@@ -348,7 +348,7 @@ module.exports = class ABViewGridCore extends ABViewWidget {
          }
       }
 
-      // check to see if there are hidden fields
+      // check to see if there are Summary fields
       if (this.settings.summaryColumns?.length) {
          // find if the deleted field is in the array
          let index = this.settings.summaryColumns.indexOf(field.id);

--- a/views/ABViewImageCore.js
+++ b/views/ABViewImageCore.js
@@ -30,6 +30,24 @@ module.exports = class ABViewImageCore extends ABViewWidget {
    ///
 
    /**
+    * @method componentList
+    * return the list of components available on this view to display in the editor.
+    */
+   componentList() {
+      return [];
+   }
+
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      return null;
+   }
+
+   /**
     * @method fromValues()
     *
     * initialze this object with the given set of values.

--- a/views/ABViewKanbanCore.js
+++ b/views/ABViewKanbanCore.js
@@ -40,7 +40,7 @@ const ABViewKanbanPropertyComponentDefaults = {
 const ABViewDefaults = {
    key: "kanban",
    // {string}
-   // unique key identifier for this ABViewForm
+   // unique key identifier for this ABView object
 
    icon: "columns",
    // {string}
@@ -72,6 +72,9 @@ module.exports = class ABViewKanbanCore extends ABViewWidget {
    toObj() {
       var obj = super.toObj();
       obj.settings.template = this.TextTemplate.toObj();
+      // NOTE: this corrects the initial save where this.id == undefined
+      // all the rest will set the .id correctly.
+      obj.settings.template.id = `${this.id}_template`;
       return obj;
    }
 

--- a/views/ABViewLayoutCore.js
+++ b/views/ABViewLayoutCore.js
@@ -69,4 +69,14 @@ module.exports = class ABViewLayoutCore extends ABViewWidget {
          }
       }
    }
+
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      return null;
+   }
 };

--- a/views/ABViewListCore.js
+++ b/views/ABViewListCore.js
@@ -25,6 +25,14 @@ module.exports = class ABViewLabelCore extends ABViewWidget {
       return ABViewListPropertyComponentDefaults;
    }
 
+   /**
+    * @method componentList
+    * return the list of components available on this view to display in the editor.
+    */
+   componentList() {
+      return [];
+   }
+
    field() {
       var dv = this.datacollection;
       if (!dv) return null;
@@ -32,6 +40,6 @@ module.exports = class ABViewLabelCore extends ABViewWidget {
       var object = dv.datasource;
       if (!object) return null;
 
-      return object.fields((f) => f.id == this.settings.field)[0];
+      return object.fieldByID(this.settings.field);
    }
 };

--- a/views/ABViewMenuCore.js
+++ b/views/ABViewMenuCore.js
@@ -130,6 +130,16 @@ module.exports = class ABViewMenuCore extends ABViewWidget {
       }
    }
 
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      return null;
+   }
+
    AddPagesToView(view, pages) {
       if (!view || !pages) return;
 

--- a/views/ABViewPivotCore.js
+++ b/views/ABViewPivotCore.js
@@ -56,7 +56,7 @@ module.exports = class ABViewPivotCore extends ABViewWidget {
             ABViewPivotPropertyComponentDefaults.separateLabel
       );
       this.settings.min = JSON.parse(
-         this.settings.allowDelete || ABViewPivotPropertyComponentDefaults.min
+         this.settings.min || ABViewPivotPropertyComponentDefaults.min
       );
       this.settings.max = JSON.parse(
          this.settings.max || ABViewPivotPropertyComponentDefaults.max

--- a/views/ABViewReportsManagerCore.js
+++ b/views/ABViewReportsManagerCore.js
@@ -2,13 +2,13 @@ const ABViewWidget = require("../../platform/views/ABViewWidget");
 
 const ABViewReportManagerPropertyComponentDefaults = {
    moduleList: [],
-   queryList: []
+   queryList: [],
 };
 
 const ABViewDefaults = {
    key: "reportsManager", // {string} unique key for this view
    icon: "wpforms", // {string} fa-[icon] reference for this view
-   labelKey: "Reports Manager" // {string} the multilingual label key for the class label
+   labelKey: "Reports Manager", // {string} the multilingual label key for the class label
 };
 
 module.exports = class ABViewReportsManagerCore extends ABViewWidget {
@@ -69,5 +69,14 @@ module.exports = class ABViewReportsManagerCore extends ABViewWidget {
    componentList() {
       return [];
    }
-};
 
+   /**
+    * @property datacollection
+    * return data source
+    * NOTE: this view doesn't track a DataCollection.
+    * @return {ABDataCollection}
+    */
+   get datacollection() {
+      return null;
+   }
+};


### PR DESCRIPTION
Initial work on getting the Interface warnings in place.

In addition to the warnings, numerous Interface builder and ABView components were updated, as well as some missing platform features.

Things that still need to be addressed:
- ABViewKanban: the editor doesn't have a way for you to create a template for the individual Kanban items.
  - also there is a small glitch in the editor when the Kanban is initially displayed and webix resizes the display too small. Any adjustment to the webix interface (like slightly moving a resize bar) corrects it.
- ABviewPivot: did we ever have this implemented? Someone needs to go review the actual component and make sure it is working for webix v8. I do have what was listed as the properties implemented, just no widget shows.
- ABViewForm: still need to scan through the SubmitRules and RecordRules to post any misconfiguration errors.