### PR TITLE
Is/hotfix process connections

### DIFF
--- a/ABProcessCore.js
+++ b/ABProcessCore.js
@@ -165,20 +165,16 @@ module.exports = class ABProcessCore extends ABMLClass {
     *                should be returned.
     * @return [{SimpleConnectionObj}]
     */
-   connections(fn) {
-      if (!fn)
-         fn = () => {
-            return true;
-         };
-
-      // If parent, merge connections
-      if (this.process && this.key === "SubProcess") {
-         Object.assign(this._connections, this.process._connections);
-      }
-
+   connections(fn = () => true) {
       var allConnections = Object.keys(this._connections).map((e) => {
          return this._connections[e];
       });
+
+      // If parent, merge connections
+      if (this.process /*&& this.key === "SubProcess"*/) {
+         allConnections = allConnections.concat(this.process.connections());
+      }
+
       return allConnections.filter(fn);
    }
 

--- a/ABProcessCore.js
+++ b/ABProcessCore.js
@@ -171,7 +171,7 @@ module.exports = class ABProcessCore extends ABMLClass {
       });
 
       // If parent, merge connections
-      if (this.process /*&& this.key === "SubProcess"*/) {
+      if (this.process && this.key === "SubProcess") {
          allConnections = allConnections.concat(this.process.connections());
       }
 

--- a/process/tasks/ABProcessTaskServiceInsertRecordCore.js
+++ b/process/tasks/ABProcessTaskServiceInsertRecordCore.js
@@ -122,7 +122,12 @@ module.exports = class InsertRecordCore extends ABProcessElement {
          {
             key: `${this.id}.[PK]`,
             label: `${this.label}-> Inserted record [PK]`,
-            field: "InsertedRecord",
+            field: {
+               id: this.id,
+               object: { id: this.objectID },
+               key: "InsertedRecord",
+               columnName: "uuid",
+            },
             object: this.objectID,
             set: true,
          },


### PR DESCRIPTION
1. Don't modify _connections (as Johnny pointed out
2. hotfix why the child records weren't getting connected on Staging2

![image](https://user-images.githubusercontent.com/8057443/233010194-159bb989-8a65-4feb-ac56-edfcd0d040fb.png)

RowFilterCore was erroring out when it tried to check my "insertRecord" field.
```
fieldsLoad(fields = [], object = null) {
      this._Fields = fields.filter((f) => f && f.fieldIsFilterable());
```

Filling out the returned field as an object seems to have fixed it.

If we ever want to use a field from InsertRecord that is NOT a uuid: this will have to be refactored:
ex ABQLSetSaveCore.js -> processDataField()

https://github.com/digi-serve/ns_app/issues/224
