### PR TITLE
Handle null rowData after unset cusor

### DIFF
--- a/dataFields/ABFieldNumberCore.js
+++ b/dataFields/ABFieldNumberCore.js
@@ -276,7 +276,6 @@ module.exports = class ABFieldNumberCore extends ABField {
 
    format(rowData) {
       if (
-         rowData == null ||
 	 rowData?.[this.columnName] == null ||
          (rowData[this.columnName] != 0 && rowData[this.columnName] == "")
       )

--- a/dataFields/ABFieldNumberCore.js
+++ b/dataFields/ABFieldNumberCore.js
@@ -276,8 +276,8 @@ module.exports = class ABFieldNumberCore extends ABField {
 
    format(rowData) {
       if (
-	 rowData == null ||
-         rowData[this.columnName] == null ||
+         rowData == null ||
+	 rowData?.[this.columnName] == null ||
          (rowData[this.columnName] != 0 && rowData[this.columnName] == "")
       )
          return "";

--- a/dataFields/ABFieldNumberCore.js
+++ b/dataFields/ABFieldNumberCore.js
@@ -276,7 +276,7 @@ module.exports = class ABFieldNumberCore extends ABField {
 
    format(rowData) {
       if (
-	 typeof rowData == "undefined" ||
+	 rowData == null ||
          rowData[this.columnName] == null ||
          (rowData[this.columnName] != 0 && rowData[this.columnName] == "")
       )

--- a/dataFields/ABFieldNumberCore.js
+++ b/dataFields/ABFieldNumberCore.js
@@ -276,6 +276,7 @@ module.exports = class ABFieldNumberCore extends ABField {
 
    format(rowData) {
       if (
+	 typeof rowData == "undefined" ||
          rowData[this.columnName] == null ||
          (rowData[this.columnName] != 0 && rowData[this.columnName] == "")
       )


### PR DESCRIPTION
When we set a cursor to null to unset we also fire a series of updates to the UI. If we do not handle properly a null value here the code errors and the UI is not updated.