### PR TITLE
[fix] prevent mapping errors when __relation data is empty.

### DIFF
--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -809,8 +809,23 @@ module.exports = class ABModelCore {
             // }
 
             // Change property name of connected field
-            if (!d[c.columnName])
-               d[c.columnName] = d[relationName].map((i) => i[olPK]);
+            if (!d[c.columnName]) {
+               if (c.linkType == "one") {
+                  if (d[relationName]) {
+                     d[c.columnName] = d[relationName][olPK];
+                  } else {
+                     d[c.columnName] = null;
+                  }
+               } else {
+                  if (d[relationName]) {
+                     d[c.columnName] = (d[relationName] || []).map(
+                        (i) => i[olPK]
+                     );
+                  } else {
+                     d[c.columnName] = [];
+                  }
+               }
+            }
          });
 
          if (mlFields.length) {

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -810,7 +810,7 @@ module.exports = class ABModelCore {
 
             // Change property name of connected field
             if (!d[c.columnName]) {
-               if (c.linkType == "one") {
+               if (c.linkType() == "one") {
                   if (d[relationName]) {
                      d[c.columnName] = d[relationName][olPK];
                   } else {
@@ -818,9 +818,34 @@ module.exports = class ABModelCore {
                   }
                } else {
                   if (d[relationName]) {
-                     d[c.columnName] = (d[relationName] || []).map(
-                        (i) => i[olPK]
-                     );
+                     if (Array.isArray(d[relationName])) {
+                        try {
+                           d[c.columnName] = (d[relationName] || []).map(
+                              (i) => i[olPK]
+                           );
+                        } catch (e) {
+                           console.log("+++++++++++++++");
+                           console.log(`ID:[${c.id}]`);
+                           console.log(`ColumnName:[${c.label}]`);
+                           console.log(`relationName:[${relationName}]`);
+                           console.log(`linkType:[${c.linkType()}]`);
+                           console.log("data:");
+                           console.log(JSON.stringify(d[relationName]));
+                           console.log("+++++++++++++++");
+                        }
+                     } else {
+                        // this is strange: supposed to be "many" but coming in
+                        // as "one"
+                        console.log("+++++++++++++++");
+                        console.log(`ID:[${c.id}]`);
+                        console.log(`ColumnName:[${c.label}]`);
+                        console.log(`relationName:[${relationName}]`);
+                        console.log(`linkType:[${c.linkType()}]`);
+                        console.log("data:");
+                        console.log(JSON.stringify(d[relationName]));
+                        console.log("+++++++++++++++");
+                        d[c.columnName] = [d[relationName][olPK]];
+                     }
                   } else {
                      d[c.columnName] = [];
                   }


### PR DESCRIPTION
Quick fix to prevent errors when our __relation data is actually empty.