### PR TITLE
Hide child dc data

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -599,8 +599,11 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       }
 
       let filterData = (rowData) => {
-         // if link dc cursor is null, then show all data
-         if (linkCursor == null) return true;
+         // if link dc cursor is null:
+         // ... if there's no parent show all data
+         // ... if we have a parent hide all data - address cases where user see
+         //     unexpected data (ns_app#318) - should this be a DC setting?
+         if (linkCursor == null) return dvLink ? false : true;
          else return this.isParentFilterValid(rowData);
       };
 

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -603,7 +603,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          // ... if there's no parent show all data
          // ... if we have a parent hide all data - address cases where user see
          //     unexpected data (ns_app#318) - should this be a DC setting?
-         if (linkCursor == null) return dvLink ? false : true;
+         if (!linkCursor) return dvLink ? false : true;
          else return this.isParentFilterValid(rowData);
       };
 
@@ -1874,11 +1874,11 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
             // In order to get the total_count updated I had to use .load()
             this.__dataCollection.load(async () => {
-               if (this.settings.loadAll) {
+               // if (this.settings.loadAll) {
                   setTimeout(() => {
                      this.refreshLinkCursor();
                   }, 250);
-               }
+               // }
 
                return {
                   // NOTE: return a empty array to prevent render items in DataTable twice. (Items are rendered in .queuedParse function)


### PR DESCRIPTION
This changes the default behavior of a linked datacollection when no cursor is set on the parent. Currently we show all data, but hiding it makes more sense to me. This should help with digi-serve/ns_app#318

## Release Notes
<!-- #release_notes -->
- Hide data in a linked datacollection if the parent datacollection's cursor is not
<!-- /release_notes --> 
