### PR TITLE
Restore NetworkRest to properly update local data in client

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1609,8 +1609,20 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
                // if don't have .loadAll set,  we'll need to reload our data:
                if (!this.settings?.loadAll) {
+                  // find out how many entries we have already loaded and try to
+                  // load at least that many again.:
+                  let count = 20;
+                  if (this.__dataCollection.count() > count)
+                     count = this.__dataCollection.count();
+                  if (this.__treeCollection?.count() > count)
+                     count = this.__treeCollection.count();
+
+                  let currCursor = this.__dataCollection.getCursor();
                   this.clearAll();
-                  this.reloadData(0, 20);
+                  this.reloadData(0, count).then(() => {
+                     this.__dataCollection.setCursor(currCursor);
+                     this.emit("cursorSelect", currCursor);
+                  });
                   return;
                }
 

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1867,6 +1867,8 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       if (this.__reloadWheres) {
          wheres = this.__reloadWheres;
       }
+      wheres.glue = wheres.glue || "and";
+      wheres.rules = wheres.rules || [];
 
       const __additionalWheres = {
          glue: "and",
@@ -2485,6 +2487,10 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             rules: [],
          }
       );
+      // sanity checks:
+      // I've learned not to trust: this.settings.objectWorkspace
+      filter.glue = filter.glue || "and";
+      filter.rules = filter.rules || [];
 
       // if there is a linkRule, add it to filter
       let linkRule = this.ruleLinkedData(); // returns a rule if we are linked
@@ -2520,7 +2526,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          }
       }
 
-      if (filter.rules.length > 0) {
+      if ((filter.rules || []).length > 0) {
          this.__filterDatacollection.setValue(filter);
       } else {
          this.__filterDatacollection.setValue(


### PR DESCRIPTION
We had certain dependencies on the client of depending on the Socket Updates to properly update our local client data.  

however, this won't display the application correctly when we set out Network = "rest".  So these changes should enable a local client app to properly update itself without the input of socket updates.

## Release Notes
<!-- #release_notes -->
- [fix] revamp our "update" and "delete" handlers to emit "cursorStale" signals
<!-- /release_notes --> 
