### PR TITLE
Fix error `this.warningMessage` is not a function

### DIFF
--- a/ql/ABQLRootObjectCore.js
+++ b/ql/ABQLRootObjectCore.js
@@ -32,7 +32,7 @@ class ABQLObjectCore extends ABQL {
    ///
    /// Instance Methods
    ///
-   initObject(attributes) {
+   initObject(/* attributes */) {
       if (!this.object && this.params) {
          const objNameDef = this.parameterDefinitions.find((pDef) => {
             return pDef.type === "objectName";
@@ -44,7 +44,8 @@ class ABQLObjectCore extends ABQL {
          }
 
          if (!this.object) {
-            this.warningMessage("has no object set.", {
+            // This function exists on platform_web but not platform_service
+            this.warningMessage?.("has no object set.", {
                objectID: this.objectID,
             });
          }


### PR DESCRIPTION
[AB-DEFINITION-MANAGER-1J](https://appdev-designs.sentry.io/issues/4977849458/)


## Release Notes
<!-- #release_notes -->
- Fix error `this.warningMessage` is not a function
<!-- /release_notes --> 
