### PR TITLE
Fix cursor stale operations when working with Linked Data that has no Connections Populated

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1609,8 +1609,20 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
                // if don't have .loadAll set,  we'll need to reload our data:
                if (!this.settings?.loadAll) {
+                  // find out how many entries we have already loaded and try to
+                  // load at least that many again.:
+                  let count = 20;
+                  if (this.__dataCollection.count() > count)
+                     count = this.__dataCollection.count();
+                  if (this.__treeCollection?.count() > count)
+                     count = this.__treeCollection.count();
+
+                  let currCursor = this.__dataCollection.getCursor();
                   this.clearAll();
-                  this.reloadData(0, 20);
+                  this.reloadData(0, count).then(() => {
+                     this.__dataCollection.setCursor(currCursor);
+                     this.emit("cursorSelect", currCursor);
+                  });
                   return;
                }
 

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1055,12 +1055,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          // #Johnny: removing this check.  A DC that is following another cursor
          // still has a value that might need updating.
          // DC who is following cursor should update only current cursor.
-         // if (
-         //    this.isCursorFollow &&
-         //    this.getCursor()?.id != (values[obj.PK()] ?? values.id)
-         // ) {
-         //    return;
-         // }
+         if (
+            this.isCursorFollow &&
+            this.getCursor()?.id != (values[obj.PK()] ?? values.id)
+         ) {
+            return;
+         }
 
          let needUpdate = false;
          let isExists = false;
@@ -1377,7 +1377,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          if (updateCursor) {
             this.emit("cursorStale", null);
          }
-         // this.updateRelationalDataFromLinkDC(data.objectId, values);
+         this.updateRelationalDataFromLinkDC(data.objectId, values);
          this.refreshLinkCursor();
 
          this.setStaticCursor();

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -2050,6 +2050,13 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       });
    }
 
+   /**
+    * @method shouldPopulate()
+    * Return our populate status. We now want to query this info outside this
+    * object.
+    * @return {bool|Array}
+    *         true/false,  or an array of columnNames that are being populated.
+    */
    get shouldPopulate() {
       return (
          this.settings.populate ??

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1867,6 +1867,8 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       if (this.__reloadWheres) {
          wheres = this.__reloadWheres;
       }
+      wheres.glue = wheres.glue || "and";
+      wheres.rules = wheres.rules || [];
 
       const __additionalWheres = {
          glue: "and",
@@ -2485,6 +2487,10 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             rules: [],
          }
       );
+      // sanity checks:
+      // I've learned not to trust: this.settings.objectWorkspace
+      filter.glue = filter.glue || "and";
+      filter.rules = filter.rules || [];
 
       // if there is a linkRule, add it to filter
       let linkRule = this.ruleLinkedData(); // returns a rule if we are linked
@@ -2520,7 +2526,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          }
       }
 
-      if (filter.rules.length > 0) {
+      if ((filter.rules || []).length > 0) {
          this.__filterDatacollection.setValue(filter);
       } else {
          this.__filterDatacollection.setValue(

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1055,12 +1055,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          // #Johnny: removing this check.  A DC that is following another cursor
          // still has a value that might need updating.
          // DC who is following cursor should update only current cursor.
-         if (
-            this.isCursorFollow &&
-            this.getCursor()?.id != (values[obj.PK()] ?? values.id)
-         ) {
-            return;
-         }
+         // if (
+         //    this.isCursorFollow &&
+         //    this.getCursor()?.id != (values[obj.PK()] ?? values.id)
+         // ) {
+         //    return;
+         // }
 
          let needUpdate = false;
          let isExists = false;
@@ -1377,7 +1377,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          if (updateCursor) {
             this.emit("cursorStale", null);
          }
-         this.updateRelationalDataFromLinkDC(data.objectId, values);
+         // this.updateRelationalDataFromLinkDC(data.objectId, values);
          this.refreshLinkCursor();
 
          this.setStaticCursor();

--- a/ql/ABQLRootObjectCore.js
+++ b/ql/ABQLRootObjectCore.js
@@ -32,7 +32,7 @@ class ABQLObjectCore extends ABQL {
    ///
    /// Instance Methods
    ///
-   initObject(attributes) {
+   initObject(/* attributes */) {
       if (!this.object && this.params) {
          const objNameDef = this.parameterDefinitions.find((pDef) => {
             return pDef.type === "objectName";
@@ -44,7 +44,8 @@ class ABQLObjectCore extends ABQL {
          }
 
          if (!this.object) {
-            this.warningMessage("has no object set.", {
+            // This function exists on platform_web but not platform_service
+            this.warningMessage?.("has no object set.", {
                objectID: this.objectID,
             });
          }


### PR DESCRIPTION

OK, this was a tricky one!  

Pong's data collection test case that checks to make sure the linked DC continues to have it's data even after the cursor stale event fires, turns out to be quite complex.

In this setup:  DC(test-kcs2) is created with **NO CONNECTIONS POPULATED**.
and the linked DC(test-kcs-link-test-kcs-2) is linked to that one.

NOTE: in the ABDesigner we specifically warn users about creating a DC with **NO CONNECTIONS POPULATED**.  Our tip says: `"Will load fast, but won't work with linked data collections"` 

But you know what ... **we did it anyway!**

And, actually I do consider this a pretty good test case, because if we are going to allow a user to design something this way, we need to make sure things still work.   So, **good job!**

This fix now identifies when the linked DC doesn't have the relevant data loaded and responds differently.  

In the case where the data is available, we use the more efficient method of loading any missing data.

in the case where we are missing the relevant populated data, we simply do a reload to make sure everything is correct.

## Release Notes
<!-- #release_notes -->
- [fix] cursor stale updates when the linked DC doesn't have any of it's connections populated
<!-- /release_notes --> 
