### PR TITLE
Proper method to store the Relation Data on an update.

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1318,7 +1318,9 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         updateItemData[f.relationName()] = rowRelateVal;
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
-                        ].map((v) => v.id || v[PK] || v);
+                        ].map(
+                           (v) => f.getRelationValue(v) /*v.id || v[PK] || v*/
+                        );
                      } else if (
                         !Array.isArray(rowRelateVal) &&
                         (rowRelateVal != values.id ||
@@ -1327,7 +1329,9 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         valIsRelated
                      ) {
                         updateItemData[f.relationName()] = values;
-                        updateItemData[f.columnName] = values.id || values;
+                        // make ConnectedField use .getRelationValue() here!
+                        updateItemData[f.columnName] =
+                           f.getRelationValue(values);
                      }
                   });
 


### PR DESCRIPTION
The `ab.datacollection.update` handler was improperly storing the updated `data[connection]` value from its `data[connection_relation]` value.  The method used was valid for all connection types except `User` connections, which want to use `username` instead of it's `uuid`.

Using the `.getRelationValue()` method of the connection field returns the proper value.

## Release Notes
<!-- #release_notes -->
- [fix] properly pull the relation value when storing the connection data.
<!-- /release_notes --> 

## Test Status
Believe it or not, this was detected by an existing Comment Test: searching for the user name on a comment.  It was due to the `one:*` link type case.  We should probably create a test to verify the `many:*` cases.
