### PR TITLE
Fix the `contain_user` condition checks

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1804,6 +1804,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       DC.init();
 
       return new Promise((resolve, reject) => {
+         /* eslint-disable no-fallthrough */
          switch (DC.dataStatus) {
             // if that DC hasn't started initializing yet, start it!
             case DC.dataStatusFlag.notInitial:
@@ -1811,7 +1812,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             // no break;
 
             // once in the process of initializing
-            /* eslint-disable no-fallthrough*/
+
             case DC.dataStatusFlag.initializing:
                /* eslint-enable no-fallthrough*/
                // listen for "initializedData" event from the DC
@@ -1837,6 +1838,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                resolve();
                break;
          }
+         /* eslint-enable no-fallthrough */
       });
    }
 

--- a/ABFactoryCore.js
+++ b/ABFactoryCore.js
@@ -825,7 +825,7 @@ class ABFactory extends EventEmitter {
          var newStep = new ABStep(params, this);
          return newStep;
       }
-      return null;
+      // return null;
    }
 
    //

--- a/ABHintCore.js
+++ b/ABHintCore.js
@@ -35,9 +35,8 @@ module.exports = class ABHintCore extends ABMLClass {
       }
     }
     */
-      let active = attributes?.settings.hasOwnProperty("active")
-         ? attributes?.settings?.active
-         : "1";
+
+      let active = attributes?.settings?.active ?? "1";
 
       this.id = attributes?.id || "";
       this.name = attributes?.name || "New Tutorial";

--- a/ABMobileAppCore.js
+++ b/ABMobileAppCore.js
@@ -62,7 +62,7 @@ module.exports = class ABMobileAppCore extends ABMLClass {
          type: this.type || "mobile.application",
          name: this.name,
          settings: this.settings,
-         translations: obj.translations
+         translations: obj.translations,
       };
    }
 };

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -688,51 +688,7 @@ module.exports = class ABModelCore {
       // return this.request("put", params);
    }
 
-   /**
-    * @method csvUnpack()
-    * unpack our compressed data into our exptected json format.
-    *
-    * Incoming data should look like:
-    * {
-    *    csv_packed: {
-    *       objID: {uuid},
-    *       data: "csvString: 1st Row = column headers ",
-    *       connections:{
-    *          {ConnectedObject1.ID} : "csvString of connection data",
-    *          {ConnectedObject2.ID} : "csvString of connection data",
-    *          ...
-    *          {ConnectedObjectN.ID} : "csvString of connection data",
-    *       }
-    *    }
-    * }
-    *
-    * each "csvString" will
-    * - contain the object's properties as the 1st row
-    * - only have the connection field with ID's separated by "|"
-    * - all __relation fields are pulled out and stored in the
-    *   {ConnectedObject} csvString
-    *
-    * This function will recombine this data into our expected
-    * [ {row1 with embedded relations}, {row2 with embedded relations},...]
-    *
-    * @param {json} data
-    *        json structure with csv packed data
-    * @return {array}
-    */
-   csvUnpack(data) {
-      if (!data.csv_packed) {
-         return data;
-      }
-      let coreObject = this.AB.objectByID(data.csv_packed.objID);
-      let coreData = this.csvUnpackCSVToArray(coreObject, data.csv_packed.data);
-   }
-
    normalizeData(data) {
-      // check for CSV_PACKED data
-      if (data.csv_packed) {
-         data = this.csvUnpack(data);
-      }
-
       // convert to array
       if (!(data instanceof Array)) data = [data];
 

--- a/ABProcessCore.js
+++ b/ABProcessCore.js
@@ -408,7 +408,7 @@ module.exports = class ABProcessCore extends ABMLClass {
       //       : values[0]
       //    : null;
 
-      var tasksToAsk = this.allPreviousTasks(currElement)
+      var tasksToAsk = this.allPreviousTasks(currElement);
       var values = queryPreviousTasks(tasksToAsk, "processData", params, this);
       return values.length > 0
          ? values.length > 1

--- a/ABScopeCore.js
+++ b/ABScopeCore.js
@@ -49,7 +49,7 @@ module.exports = class ABScopeCore {
          createdBy: this.createdBy,
          filter: this.filter,
          allowAll: this.allowAll || false,
-         objectIds: this.objects().map((o) => o.id)
+         objectIds: this.objects().map((o) => o.id),
       };
    }
 

--- a/FilterComplexCore.js
+++ b/FilterComplexCore.js
@@ -402,7 +402,7 @@ module.exports = class FilterComplexCore extends ABComponent {
       let result = false;
 
       // if (Array.isArray(value)) value = [value];
-
+      /* eslint-disable no-fallthrough */
       switch (rule) {
          case "is_current_user":
             result = value == this.Account.username;
@@ -412,7 +412,8 @@ module.exports = class FilterComplexCore extends ABComponent {
             break;
          case "contain_current_user":
             compareValue = this.Account.username;
-         // break;  <-- NO BREAK HERE
+         // break;  <-- NO BREAK HERE: fall through to "equals"
+
          case "equals":
             if (!Array.isArray(value)) value = [value];
 
@@ -422,7 +423,8 @@ module.exports = class FilterComplexCore extends ABComponent {
             break;
          case "not_contain_current_user":
             compareValue = this.Account.username;
-         // break;  <-- NO BREAK HERE
+         // break;  <-- NO BREAK HERE: fall through to "not_equals"
+
          case "not_equal":
             if (!Array.isArray(value)) value = [value];
 
@@ -434,6 +436,7 @@ module.exports = class FilterComplexCore extends ABComponent {
             result = this.queryFieldValid(value, rule, compareValue);
             break;
       }
+      /* eslint-enable no-fallthrough */
 
       return result;
    }

--- a/FilterComplexCore.js
+++ b/FilterComplexCore.js
@@ -412,7 +412,7 @@ module.exports = class FilterComplexCore extends ABComponent {
             break;
          case "contain_current_user":
             compareValue = this.Account.username;
-            break;
+         // break;  <-- NO BREAK HERE
          case "equals":
             if (!Array.isArray(value)) value = [value];
 
@@ -422,7 +422,7 @@ module.exports = class FilterComplexCore extends ABComponent {
             break;
          case "not_contain_current_user":
             compareValue = this.Account.username;
-            break;
+         // break;  <-- NO BREAK HERE
          case "not_equal":
             if (!Array.isArray(value)) value = [value];
 

--- a/dataFields/ABFieldAutoIndexCore.js
+++ b/dataFields/ABFieldAutoIndexCore.js
@@ -150,4 +150,3 @@ module.exports = class ABFieldAutoIndexCore extends ABField {
       }
    }
 };
-

--- a/dataFields/ABFieldDateCore.js
+++ b/dataFields/ABFieldDateCore.js
@@ -398,9 +398,11 @@ module.exports = class ABFieldDateCore extends ABField {
    // }
 
    exportValue(value) {
-      return value ? this.AB.rules.toDateFormat(value, {
-         format: "YYYY-MM-DD",
-      }) : "";
+      return value
+         ? this.AB.rules.toDateFormat(value, {
+              format: "YYYY-MM-DD",
+           })
+         : "";
       // return this.convertToMoment(value).format("YYYY-MM-DD");
    }
 

--- a/dataFields/ABFieldEmailCore.js
+++ b/dataFields/ABFieldEmailCore.js
@@ -124,7 +124,8 @@ module.exports = class ABFieldEmailCore extends ABField {
     */
    isValidData(data, validator) {
       if (data[this.columnName]) {
-         const Reg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+         const Reg =
+            /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
          let value = data[this.columnName];
          value = String(value).toLowerCase();

--- a/dataFields/ABFieldFileCore.js
+++ b/dataFields/ABFieldFileCore.js
@@ -180,7 +180,9 @@ module.exports = class ABFieldFileCore extends ABField {
       if ("string" === typeof val) {
          try {
             myParameter[this.columnName] = JSON.parse(val);
-         } catch (e) {}
+         } catch (e) {
+            /* ignore */
+         }
       }
 
       return myParameter;

--- a/dataFields/ABFieldNumberCore.js
+++ b/dataFields/ABFieldNumberCore.js
@@ -276,7 +276,7 @@ module.exports = class ABFieldNumberCore extends ABField {
 
    format(rowData) {
       if (
-	 rowData?.[this.columnName] == null ||
+         rowData?.[this.columnName] == null ||
          (rowData[this.columnName] != 0 && rowData[this.columnName] == "")
       )
          return "";

--- a/process/ABProcessEngineCore.js
+++ b/process/ABProcessEngineCore.js
@@ -36,9 +36,8 @@ module.exports = class ABProcessEngineCore {
 
 */
          };
-         var processDefinitions = this.instance.jsonDefinition[
-            "bpmn2:definitions"
-         ]["bpmn2:process"];
+         var processDefinitions =
+            this.instance.jsonDefinition["bpmn2:definitions"]["bpmn2:process"];
 
          this.setHashDiagramObjects(processDefinitions);
 
@@ -181,4 +180,3 @@ module.exports = class ABProcessEngineCore {
       });
    }
 };
-

--- a/process/ABProcessTaskManager.js
+++ b/process/ABProcessTaskManager.js
@@ -50,16 +50,14 @@ AllProcessElements.forEach((ELEMENT) => {
    switch (ELEMENT.defaults().category) {
       case "start":
       case "end":
-         DEFINITIONTYPES[
-            ELEMENT.DiagramReplace().target.eventDefinitionType
-         ] = ELEMENT.defaults();
+         DEFINITIONTYPES[ELEMENT.DiagramReplace().target.eventDefinitionType] =
+            ELEMENT.defaults();
          break;
 
       case "gateway":
       case "task":
-         DEFINITIONTYPES[
-            ELEMENT.DiagramReplace().target.type
-         ] = ELEMENT.defaults();
+         DEFINITIONTYPES[ELEMENT.DiagramReplace().target.type] =
+            ELEMENT.defaults();
          break;
    }
 });
@@ -135,4 +133,3 @@ module.exports = {
       return DEFINITIONTYPES[key];
    },
 };
-

--- a/process/tasks/ABProcessElementCore.js
+++ b/process/tasks/ABProcessElementCore.js
@@ -238,7 +238,7 @@ module.exports = class ABProcessTaskCore extends ABMLClass {
 
       var myDiagramObj = instance.hashDiagramObjects[this.diagramID];
       if (!myDiagramObj) {
-         var error = new Error(
+         let error = new Error(
             `Configuration Error: Did not find my definition for dID[${this.diagramID}]`
          );
          this.onError(instance, error);
@@ -255,7 +255,7 @@ module.exports = class ABProcessTaskCore extends ABMLClass {
       // find my possible exits:
       var exitFlows = myDiagramObj["bpmn2:outgoing"];
       if (!exitFlows) {
-         var error = new Error(
+         let error = new Error(
             `Configuration Error: Did not find any outgoing flows for dID[${this.diagramID}]`
          );
          this.AB.notify.builder(error, { task: this });
@@ -288,7 +288,7 @@ module.exports = class ABProcessTaskCore extends ABMLClass {
                   nextTasks.push(targetTask);
                }
             } else {
-               var error = new Error(
+               let error = new Error(
                   `Configuration Error: No ProcessTask instance for diagramID[${tid}]`
                );
                this.AB.notify.builder(error, { task: this });

--- a/process/tasks/ABProcessGatewayExclusiveCore.js
+++ b/process/tasks/ABProcessGatewayExclusiveCore.js
@@ -93,7 +93,6 @@ module.exports = class ABProcessGatewayExclusiveCore extends ABProcessElement {
    //// Process Instance Methods
    ////
 
-
    /**
     * initState()
     * setup this task's initial state variables

--- a/process/tasks/ABProcessTaskUserApprovalCore.js
+++ b/process/tasks/ABProcessTaskUserApprovalCore.js
@@ -210,7 +210,7 @@ module.exports = class ABProcessTaskUserApprovalCore extends ABProcessElement {
                options: options,
             },
          },
-         myObj,
+         myObj
       );
 
       // NOTE: We are pretending our response is a type of ABFieldList. But our

--- a/process/tasks/ABProcessTriggerLifecycleCore.js
+++ b/process/tasks/ABProcessTriggerLifecycleCore.js
@@ -164,9 +164,16 @@ module.exports = class ABProcessTriggerLifecycle extends ABProcessTrigger {
             } else if (parts[1] == "uuid") {
                return myState["data"]["uuid"];
             } else {
+               ///
+               /// Questioning the validity of this section of code.
+               /// In order to get here, we tried to find field, and it
+               /// didn't exist.
+               /// then we turn around and REPEAT the same attempt
+               /// and check for field again.
+               /*
                // parts[1] should be a field.id
-               var object = this.AB.objectByID(this.objectID);
-               var field = object.fields((f) => {
+               object = this.AB.objectByID(this.objectID);
+               field = object.fields((f) => {
                   return f.id == parts[1];
                })[0];
                if (field) {
@@ -177,6 +184,7 @@ module.exports = class ABProcessTriggerLifecycle extends ABProcessTrigger {
                      return myState["data"][field.columnName];
                   }
                }
+               */
             }
          }
       }

--- a/views/ABViewCSVImporterCore.js
+++ b/views/ABViewCSVImporterCore.js
@@ -108,7 +108,7 @@ module.exports = class ABViewCSVImporterCore extends ABViewWidget {
 
    get RecordRule() {
       let object = this.datacollection?.datasource;
-      if (!object) return;
+      if (!object) return null;
 
       if (this._recordRule == null) {
          this._recordRule = new ABRecordRule();

--- a/views/ABViewFormButtonCore.js
+++ b/views/ABViewFormButtonCore.js
@@ -93,7 +93,7 @@ module.exports = class ABViewFormButtonCore extends ABView {
       this.unTranslate(this.settings, this.settings, labels);
 
       this.settings.includeSave = JSON.parse(
-         (this.settings?.includeSave ?? true) && 
+         (this.settings?.includeSave ?? true) &&
             ABViewFormButtonPropertyComponentDefaults.includeSave
       );
       this.settings.includeCancel = JSON.parse(

--- a/views/ABViewFormCheckboxCore.js
+++ b/views/ABViewFormCheckboxCore.js
@@ -34,4 +34,3 @@ module.exports = class ABViewFormCheckboxCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewFormConnectCore.js
+++ b/views/ABViewFormConnectCore.js
@@ -69,4 +69,3 @@ module.exports = class ABViewFormConnectCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewFormCore.js
+++ b/views/ABViewFormCore.js
@@ -236,4 +236,3 @@ module.exports = class ABViewFormCore extends ABViewContainer {
       return SubmitRules.process({ data: rowData, form: this });
    }
 };
-

--- a/views/ABViewFormDatepickerCore.js
+++ b/views/ABViewFormDatepickerCore.js
@@ -40,4 +40,3 @@ module.exports = class ABViewFormDatepickerCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewFormNumberCore.js
+++ b/views/ABViewFormNumberCore.js
@@ -74,4 +74,3 @@ module.exports = class ABViewFormNumberCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewFormSelectMultipleCore.js
+++ b/views/ABViewFormSelectMultipleCore.js
@@ -36,4 +36,3 @@ module.exports = class ABViewFormSelectMultipleCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewFormSelectSingleCore.js
+++ b/views/ABViewFormSelectSingleCore.js
@@ -36,4 +36,3 @@ module.exports = class ABViewFormSelectSingleCore extends ABViewFormItem {
       return [];
    }
 };
-

--- a/views/ABViewTabCore.js
+++ b/views/ABViewTabCore.js
@@ -55,7 +55,7 @@ module.exports = class ABViewTabCore extends ABViewWidget {
       this.settings.stackTabs = parseInt(this.settings.stackTabs);
       this.settings.darkTheme = parseInt(this.settings.darkTheme);
       this.settings.sidebarWidth = parseInt(this.settings.sidebarWidth);
-      this.settings.sidebarPos = this.settings.sidebarPos;
+      // this.settings.sidebarPos = this.settings.sidebarPos;
       this.settings.iconOnTop = parseInt(this.settings.iconOnTop);
    }
 


### PR DESCRIPTION
A previous PR incorrectly added `break`s to the user condition checks.

## Release Notes
<!-- #release_notes -->
- [fix] all the various contain_user rules to complete properly
<!-- /release_notes --> 

## Test Status
Apparently we don't have a kitchen sink check that depends on a Datacollection with a condition that has a `contains_current_user` condition.
