### PR TITLE
Send an event letting UI elements know this data collection is empty.

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -702,6 +702,10 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                // if (rowId) {
                this.__dataCollection.setCursor(rowId || null);
 
+               if (this.__dataCollection.data.count() == 0) {
+                  this.emit("collectionEmpty", {});
+               }
+
                this.setCursorTree(rowId);
                // }
             }


### PR DESCRIPTION
This is the first part of addressing a Detail View bug. After this is live we can then tell the Detail View to listen for this event and update.

https://github.com/digi-serve/ab_platform_web/issues/502

## Release Notes
<!-- #release_notes -->
- Send an event letting UI elements know this data collection is empty.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
