### PR TITLE
If more than one source is selected this.datacollection is empty. If …

### DIFF
--- a/views/ABViewDocxBuilderCore.js
+++ b/views/ABViewDocxBuilderCore.js
@@ -71,7 +71,8 @@ module.exports = class ABViewDocxBuilderCore extends ABViewWidget {
       // TODO: Convert this to use ABFactory.urlFileUpload() or a ABFieldFile
       // to get the URL:
 
-      const object = this.datacollection.datasource;
+      // support uploading template when more than one data source is selected
+      const object = this.datacollections[0].datasource;
 
       // NOTE: file-upload API needs to have the id of ANY field.
       const field = object ? object.fields()[0] : null;


### PR DESCRIPTION
…one or more are selected there is an array in this.datacollections so we can just look at the first item in datacollections to avoid an error.


## Release Notes
<!-- #release_notes -->
- Support uploading DocX template when more than one source is selected.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
