### PR TITLE
properly reference the `bpmn2:definitions` from our ProcessInstance

### DIFF
--- a/process/ABProcessEngineCore.js
+++ b/process/ABProcessEngineCore.js
@@ -8,7 +8,7 @@ module.exports = class ABProcessEngineCore {
       if (!this.instance.jsonDefinition) {
          this.instance.jsonDefinition = convert.xml2js(
             this.instance.xmlDefinition,
-            { compact: true }
+            { compact: true },
          );
       }
       if (!this.instance.hashDiagramObjects) {
@@ -37,7 +37,9 @@ module.exports = class ABProcessEngineCore {
 */
          };
          var processDefinitions =
-            this.instance.jsonDefinition["bpmn2:definitions"]["bpmn2:process"];
+            this.instance.jsonDefinition.definition["bpmn2:definitions"][
+               "bpmn2:process"
+            ];
 
          this.setHashDiagramObjects(processDefinitions);
 
@@ -102,7 +104,7 @@ module.exports = class ABProcessEngineCore {
     */
    startTask() {
       return this.process.elementForDiagramID(
-         this.instance.context.startTaskID
+         this.instance.context.startTaskID,
       );
    }
 


### PR DESCRIPTION

## Release Notes
<!-- #release_notes -->
-  [fix] properly reference the `bpmn2:definitions` from our ProcessInstance
<!-- /release_notes --> 


