### PR TITLE
Prevent updates from being added to DCs that are following another

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -186,13 +186,13 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
       // Convert to boolean
       this.settings.loadAll = JSON.parse(
-         values.settings.loadAll || DefaultValues.settings.loadAll,
+         values.settings.loadAll || DefaultValues.settings.loadAll
       );
       // {bool} .settings.loadAll
       // do we load all the data at one time? false == load by pages.
 
       this.settings.isQuery = JSON.parse(
-         values.settings.isQuery || DefaultValues.settings.isQuery,
+         values.settings.isQuery || DefaultValues.settings.isQuery
       );
       // {bool} .settings.isQuery
       // is the data source for this ABDataCollection based upon an
@@ -217,7 +217,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
       // Convert to number
       this.settings.syncType = parseInt(
-         values.settings.syncType || DefaultValues.settings.syncType,
+         values.settings.syncType || DefaultValues.settings.syncType
       );
       // {int} .settings.syncType
       // how is the data between this ABDataCollection and it's
@@ -258,7 +258,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             }
          } else {
             console.error(
-               `ABDataCollection[${this.name}][${this.id}] unable to find datasource [${this.settings.datasourceID}]`,
+               `ABDataCollection[${this.name}][${this.id}] unable to find datasource [${this.settings.datasourceID}]`
             );
          }
       }
@@ -390,7 +390,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             // occassionally we have blank DCs (without .id or .name)
             // and I don't want to see errors for those
             var err = new Error(
-               `DataCollection[${this.name}][${this.id}] missing reference datasource`,
+               `DataCollection[${this.name}][${this.id}] missing reference datasource`
             );
             this.AB.notify("builder", err, { datacollection: this.toObj() });
          }
@@ -552,7 +552,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
             // filter current id for serialize
             this.__treeCollection.filter(
-               (item) => item._itemId == currItem._itemId,
+               (item) => item._itemId == currItem._itemId
             );
 
             // pull item with child items
@@ -871,7 +871,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         // and check to see that we are not loading the data serverside from cursor
                         if (
                            !this.__dataCollection.exists(
-                              updatedV[`${obj.PK()}`],
+                              updatedV[`${obj.PK()}`]
                            ) &&
                            !this.__reloadWheres
                         ) {
@@ -880,7 +880,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                            // this.__dataCollection.setCursor(rowData.id);
                         } else if (
                            !this.__dataCollection.exists(
-                              updatedV[`${obj.PK()}`],
+                              updatedV[`${obj.PK()}`]
                            ) &&
                            this.__reloadWheres
                         ) {
@@ -889,7 +889,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                               // we track bound components and flexlayout components
                               var attachedComponents =
                                  this.__bindComponentIds.concat(
-                                    this.__flexComponentIds,
+                                    this.__flexComponentIds
                                  );
                               attachedComponents.forEach((bcids) => {
                                  // if the reload button already exisits move on
@@ -930,7 +930,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                                           id: bcids + "_reloadView",
                                           view: "button",
                                           value: L(
-                                             "New data available. Click to reload.",
+                                             "New data available. Click to reload."
                                           ),
                                           css: "webix_primary webix_warn",
                                           click: function (id, event) {
@@ -940,7 +940,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                                                 .removeView(id);
                                           },
                                        },
-                                       pos,
+                                       pos
                                     );
                                  }
                               });
@@ -964,7 +964,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      let connectedFields = this.datasource.connectFields(
                         (f) =>
                            f.datasourceLink &&
-                           f.datasourceLink.id == data.objectId,
+                           f.datasourceLink.id == data.objectId
                      );
 
                      // It should always be only one item for ABObject
@@ -997,7 +997,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                               let valIsRelated = isRelated(
                                  updateRelateVal,
                                  d.id,
-                                 PK,
+                                 PK
                               );
 
                               // Relate data
@@ -1007,7 +1007,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                                     (v) =>
                                        v == updatedVals.id ||
                                        v.id == updatedVals.id ||
-                                       v[PK] == updatedVals.id,
+                                       v[PK] == updatedVals.id
                                  ).length < 1 &&
                                  valIsRelated
                               ) {
@@ -1035,18 +1035,18 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                            if (Object.keys(updateItemData).length > 0) {
                               this.__dataCollection.updateItem(
                                  d.id,
-                                 updateItemData,
+                                 updateItemData
                               );
 
                               if (this.__treeCollection)
                                  this.__treeCollection.updateItem(
                                     d.id,
-                                    updateItemData,
+                                    updateItemData
                                  );
 
                               this.emit(
                                  "update",
-                                 this.__dataCollection.getItem(d.id),
+                                 this.__dataCollection.getItem(d.id)
                               );
                            }
                         });
@@ -1102,7 +1102,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      if (localField.linkType() == "many") {
                         if (!Array.isArray(row[colName])) {
                            row[colName] = [row[colName]].filter(
-                              (r) => !this.AB.isNil(r),
+                              (r) => !this.AB.isNil(r)
                            );
                         }
                         // if it isn't already in the array, add it
@@ -1113,7 +1113,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
                         if (!Array.isArray(row[relName])) {
                            row[relName] = [row[relName]].filter(
-                              (r) => !this.AB.isNil(r),
+                              (r) => !this.AB.isNil(r)
                            );
                         }
                         if (
@@ -1198,14 +1198,14 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                            // is included as an [ {obj} ], but will also prevent
                            // [ undefined ] if row[col] isn't set:
                            row[colName] = [row[colName]].filter(
-                              (r) => !this.AB.isNil(r),
+                              (r) => !this.AB.isNil(r)
                            );
                         }
                         row[colName].push(f.getRelationValue(newData));
 
                         if (!Array.isArray(row[relName])) {
                            row[relName] = [row[relName]].filter(
-                              (r) => !this.AB.isNil(r),
+                              (r) => !this.AB.isNil(r)
                            );
                         }
                         row[relName].push(newData);
@@ -1222,7 +1222,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
                      this.emit(
                         "update",
-                        this.__dataCollection.getItem(data.rowID),
+                        this.__dataCollection.getItem(data.rowID)
                      );
                   }
                }
@@ -1310,12 +1310,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                            return (
                               item[
                                  `${this.datasource.objectAlias(
-                                    o.id,
+                                    o.id
                                  )}.${o.PK()}`
                               ] == (values[o.PK()] || values.id)
                            );
                         })
-                        .map((o) => o.id) || [],
+                        .map((o) => o.id) || []
                   );
 
                   // grouped queries
@@ -1326,12 +1326,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                               return (
                                  item[
                                     `${this.datasource.objectAlias(
-                                       o.id,
+                                       o.id
                                     )}.${o.PK()}`
                                  ] == (values[o.PK()] || values.id)
                               );
                            })
-                           .map((o) => o.id) || [],
+                           .map((o) => o.id) || []
                      );
                   }
                });
@@ -1439,7 +1439,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          // if it is a linked object
          // look for connected fields that link to the incoming objectId
          let connectedFields = obj.connectFields(
-            (f) => f.datasourceLink && f.datasourceLink.id == data.objectId,
+            (f) => f.datasourceLink && f.datasourceLink.id == data.objectId
          );
 
          // update relation data
@@ -1480,7 +1480,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                            (v) =>
                               v == values.id ||
                               v.id == values.id ||
-                              v[PK] == values.id,
+                              v[PK] == values.id
                         ).length > 0 &&
                         !valIsRelated
                      ) {
@@ -1488,7 +1488,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                            // NOTE: Special case: the incoming value.id will be .uuid
                            // however in case of User Fields, v.id == username and not .uuid
                            // so we put our default check to be v[PK] here to play nice
-                           (v) => (v[PK] || v.id || v) != values.id,
+                           (v) => (v[PK] || v.id || v) != values.id
                         );
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
@@ -1518,7 +1518,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                               (v) =>
                                  v == values.id ||
                                  v.id == values.id ||
-                                 v[PK] == values.id,
+                                 v[PK] == values.id
                            ).length > 0
                         ) {
                            // just update the one entry in my array with the new
@@ -1541,7 +1541,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
                         ].map(
-                           (v) => f.getRelationValue(v) /*v.id || v[PK] || v*/,
+                           (v) => f.getRelationValue(v) /*v.id || v[PK] || v*/
                         );
                      } else if (
                         !Array.isArray(rowRelateVal) &&
@@ -1570,7 +1570,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      if (this.__treeCollection?.exists(d.id)) {
                         const treeItem = Object.assign(
                            this.__treeCollection.getItem(d.id),
-                           updateItemData,
+                           updateItemData
                         );
                         this.__treeCollection.updateItem(d.id, treeItem);
                      }
@@ -1578,12 +1578,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      if (this.__dataCollection?.exists(d.id)) {
                         const dcItem = Object.assign(
                            this.__dataCollection.getItem(d.id),
-                           updateItemData,
+                           updateItemData
                         );
                         this.__dataCollection.updateItem(d.id, dcItem);
                         this.emit(
                            "update",
-                           this.__dataCollection.getItem(d.id),
+                           this.__dataCollection.getItem(d.id)
                         );
                         if (currCursor?.id == dcItem.id) {
                            updateCursor = dcItem;
@@ -1637,7 +1637,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          // DC who is following cursor should update only current cursor.
          if (
             this.isCursorFollow &&
-            this.getCursor()?.[PK] != (values[PK] ?? values.id)
+            this.getCursor()?.[PK] != (values[PK] ?? values?.id)
          ) {
             return;
          }
@@ -1664,7 +1664,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      if (this.__dataCollection.exists(values[PK])) {
                         this.__dataCollection.updateItem(
                            values[PK],
-                           res.data[0],
+                           res.data[0]
                         );
                      }
 
@@ -1759,7 +1759,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
          // if it is a linked object
          let connectedFields = obj.connectFields(
-            (f) => f.datasourceLink && f.datasourceLink.id == data.objectId,
+            (f) => f.datasourceLink && f.datasourceLink.id == data.objectId
          );
 
          // update relation data
@@ -1791,7 +1791,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      // ).length > 0
                   ) {
                      updateRelateVals[f.relationName()] = relateVal.filter(
-                        (v) => (v.id || v[PK] || v) != deleteId,
+                        (v) => (v.id || v[PK] || v) != deleteId
                      );
                      updateRelateVals[f.columnName] = updateRelateVals[
                         f.relationName()
@@ -2630,7 +2630,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             linkVal.filter(
                (val) =>
                   (val[PK] || val.id || val) ==
-                  (linkCursor[linkObj.PK()] || linkCursor.id || linkCursor),
+                  (linkCursor[linkObj.PK()] || linkCursor.id || linkCursor)
             ).length > 0
          );
       } else {
@@ -2695,7 +2695,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                key: fieldLink.id,
                rule: fieldLink.alias ? "contains" : "equals", // NOTE: If object is query, then use "contains" because ABOBjectQuery return JSON
                value: fieldLink.getRelationValue(
-                  dataCollectionLink.__dataCollection.getItem(linkCursorId),
+                  dataCollectionLink.__dataCollection.getItem(linkCursorId)
                ),
             };
          }
@@ -2724,7 +2724,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       // Set filter of ABObject
       if (this.__filterDatasource == null)
          this.__filterDatasource = this.AB.filterComplexNew(
-            `${this.id}_filterDatasource`,
+            `${this.id}_filterDatasource`
          );
 
       if (this.datasource) {
@@ -2753,7 +2753,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       } else {
          this.__filterDatasource.fieldsLoad([]);
          this.__filterDatasource.setValue(
-            DefaultValues.settings.objectWorkspace.filterConditions,
+            DefaultValues.settings.objectWorkspace.filterConditions
          );
       }
 
@@ -2761,14 +2761,14 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       // Apr 29, 2021 Added this code back to validate with DataCollection Filters
       if (this.__filterDatacollection == null)
          this.__filterDatacollection = this.AB.filterComplexNew(
-            `${this.id}_filterDatacollection`,
+            `${this.id}_filterDatacollection`
          );
 
       // this.__filterDatacollection.applicationLoad(
       //    this.datasource ? this.datasource.application : null
       // );
       this.__filterDatacollection.fieldsLoad(
-         this.datasource ? this.datasource.fields() : [],
+         this.datasource ? this.datasource.fields() : []
       );
 
       // if we pass in wheres, then Save that value to our internal .filterConditions
@@ -2778,7 +2778,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          this.settings.objectWorkspace?.filterConditions ?? {
             glue: "and",
             rules: [],
-         },
+         }
       );
       // sanity checks:
       // I've learned not to trust: this.settings.objectWorkspace
@@ -2823,21 +2823,21 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          this.__filterDatacollection.setValue(filter);
       } else {
          this.__filterDatacollection.setValue(
-            DefaultValues.settings.objectWorkspace.filterConditions,
+            DefaultValues.settings.objectWorkspace.filterConditions
          );
       }
 
       // Set filter of user's scope
       if (this.__filterScope == null)
          this.__filterScope = this.AB.filterComplexNew(
-            `${this.id}_filterScope`,
+            `${this.id}_filterScope`
          );
 
       if (this.datasource) {
          let scopeList = (this.userScopes || []).filter(
             (s) =>
                !s.allowAll &&
-               (s.objectIds || []).indexOf(this.datasource.id) > -1,
+               (s.objectIds || []).indexOf(this.datasource.id) > -1
          );
          if (scopeList && scopeList.length > 0) {
             // this.__filterScope.applicationLoad(this.datasource.application);
@@ -2847,12 +2847,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             let scopeRules = [];
             scopeList
                .filter(
-                  (s) => s.filter && s.filter.rules && s.filter.rules.length,
+                  (s) => s.filter && s.filter.rules && s.filter.rules.length
                )
                .forEach((s) => {
                   let sRules = (s.filter.rules || []).filter(
                      (r) =>
-                        this.datasource.fields((f) => f.id == r.key).length > 0,
+                        this.datasource.fields((f) => f.id == r.key).length > 0
                   );
 
                   scopeRules = scopeRules.concat(sRules);
@@ -2898,7 +2898,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
     */
    _dataCollectionNew(/*data*/) {
       var error = new Error(
-         "the platform.ABDataCollection._dataCollectionNew() is expected to return a proper DataCollection!",
+         "the platform.ABDataCollection._dataCollectionNew() is expected to return a proper DataCollection!"
       );
       console.error(error);
       return null;
@@ -2913,7 +2913,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
     */
    _treeCollectionNew() {
       console.error(
-         "the platform.ABDataCollection._treeCollectionNew() is expected to return a proper TreeCollection!",
+         "the platform.ABDataCollection._treeCollectionNew() is expected to return a proper TreeCollection!"
       );
       return null;
    }
@@ -2922,7 +2922,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       // TODO all this does is log "is missing?"
       if (data === {}) {
          console.log(
-            "Platform.ABDataCollection.parseTreeCollection() missing!",
+            "Platform.ABDataCollection.parseTreeCollection() missing!"
          );
       }
    }
@@ -3118,7 +3118,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
       // clonedDatacollection.__dataCollection = this.__dataCollection.copy();
       clonedDatacollection.__filterDatacollection.setValue(
-         settings.settings.objectWorkspace.filterConditions,
+         settings.settings.objectWorkspace.filterConditions
       );
 
       var parseMe = () => {
@@ -3127,8 +3127,8 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                this.__dataCollection
                   .find({})
                   .filter((row) =>
-                     clonedDatacollection.__filterDatacollection.isValid(row),
-                  ),
+                     clonedDatacollection.__filterDatacollection.isValid(row)
+                  )
             );
          }
          if (clonedDatacollection.__treeCollection) {
@@ -3136,8 +3136,8 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                this.__treeCollection
                   .find({})
                   .filter((row) =>
-                     clonedDatacollection.__filterDatacollection.isValid(row),
-                  ),
+                     clonedDatacollection.__filterDatacollection.isValid(row)
+                  )
             );
          }
       };
@@ -3178,7 +3178,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          if (obj.settings.objectWorkspace.filterConditions?.rules?.length) {
             obj.settings.objectWorkspace.filterConditions.rules =
                obj.settings.objectWorkspace.filterConditions.rules.concat(
-                  filters.rules,
+                  filters.rules
                );
          } else {
             obj.settings.objectWorkspace.filterConditions = filters;
@@ -3273,7 +3273,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       if (!this.isCursorFollow) return null;
 
       return (this.AB ?? AB).datacollectionByID(
-         this.settings.followDatacollectionID,
+         this.settings.followDatacollectionID
       );
    }
 

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1408,16 +1408,20 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             }
             // filter before add new record
             else if (this.isValidData(updatedVals)) {
-               // this means the updated record was not loaded yet so we are adding it to the top of the grid
-               // the placement will probably change on the next load of the data
-               this.__dataCollection.add(updatedVals, 0);
+               // OK we have a value, that COULD be in our DC
+               // before we add it, let's make sure we are not limited in our selection of items:
+               if (!this.isCursorFollow && !this.settings.fixSelect) {
+                  // this means the updated record was not loaded yet so we are adding it to the top of the grid
+                  // the placement will probably change on the next load of the data
+                  this.__dataCollection.add(updatedVals, 0);
 
-               if (this.__treeCollection)
-                  this.parseTreeCollection({
-                     data: [updatedVals],
-                  });
+                  if (this.__treeCollection)
+                     this.parseTreeCollection({
+                        data: [updatedVals],
+                     });
 
-               this.emit("create", updatedVals);
+                  this.emit("create", updatedVals);
+               }
             }
          }
 


### PR DESCRIPTION
This is a fix for Wei's concurrent conflict issue where updates to a row of data in one browser, was replacing the detail view in another browser.

There are times when a DC gets a notification about an updated value, and that value should now be included in the DC.  In those cases we want to add the value.  HOWEVER, in the case of a DC that is set to follow another DC/cursor, we wouldn't want to ADD the value.

The relevant fix is to prevent adding the entry if we are `.isCursorFollow` or `.fixSelect` is set:
```
else if (this.isValidData(updatedVals)) {
   // OK we have a value, that COULD be in our DC
   // before we add it, let's make sure we are not limited in our selection of items:
   if (!this.isCursorFollow && !this.settings.fixSelect) {
      // this means the updated record was not loaded yet so we are adding it to the top of the grid
      // the placement will probably change on the next load of the data
      this.__dataCollection.add(updatedVals, 0);

      if (this.__treeCollection)
         this.parseTreeCollection({
            data: [updatedVals],
         });

      this.emit("create", updatedVals);
   }
}
```

Should see if it resolves: [#525](https://github.com/digi-serve/ns_app/issues/525) or [#368](https://github.com/digi-serve/ns_app/issues/368)

## Release Notes
<!-- #release_notes -->
- [fix] prevent adding an updated value to our DC when the DC is following another
- [wip] so much eslint
<!-- /release_notes --> 

## Test Status
No test added.