### PR TITLE
Fix our formio formatting to display the proper data

### DIFF
--- a/ABObjectCore.js
+++ b/ABObjectCore.js
@@ -982,6 +982,11 @@ module.exports = class ABObjectCore extends ABMLClass {
       // ['{colId1}', ..., '{colIdN}']
       var colIds = labelData.match(/\{[^}]+\}/g);
 
+      // Using rawString to catch actual values we are pulling out.
+      // the label data might have additional characters "-" and such that will
+      // remain, and doing a .trim() on that wont catch that the label data
+      // is actually empty.
+      let rawString = "";
       if (colIds && colIds.forEach) {
          colIds.forEach((colId) => {
             var colIdNoBracket = colId.replace("{", "").replace("}", "");
@@ -989,12 +994,14 @@ module.exports = class ABObjectCore extends ABMLClass {
             var field = this.fieldByID(colIdNoBracket);
             if (field == null) return;
 
-            labelData = labelData.replace(colId, field.format(rowData) || "");
+            let valField = field.format(rowData) || "";
+            labelData = labelData.replace(colId, valField);
+            rawString = `${rawString}${valField}`;
          });
       }
 
       // if label is empty, then show .id
-      if (!labelData.trim()) {
+      if (!rawString.trim()) {
          let labelSettings = this.labelSettings || {};
          if (labelSettings && labelSettings.isNoLabelDisplay) {
             labelData = L(labelSettings.noLabelText || "[No Label]");

--- a/dataFields/ABFieldConnectCore.js
+++ b/dataFields/ABFieldConnectCore.js
@@ -284,7 +284,7 @@ module.exports = class ABFieldConnectCore extends ABField {
             .join(", ");
       // string
       else if (val) {
-         if (val.text == null) return linkedObject.displayData(rowData) || "";
+         if (val.text == null) return linkedObject.displayData(val) || "";
          else if (val.text) return val.text || "";
       }
       // empty string


### PR DESCRIPTION
When working with the formio inbox display, noticed that elements that were single values were not getting their .format value updated correctly.

We were sending the wrong value to the .displayData() in that particular case.

## Release Notes
<!-- #release_notes -->
- [wip] properly catch when a label doesn't have any valid label replacements
- [fix] send the proper data to the Object's .displayData() for formio formatting
<!-- /release_notes --> 

## Test Status
no seriously, let's get Isaac to write some.
