### PR TITLE
include a .isUser property on ABFieldUser objects

### DIFF
--- a/dataFields/ABFieldUserCore.js
+++ b/dataFields/ABFieldUserCore.js
@@ -87,6 +87,13 @@ const defaultValues = {
 module.exports = class ABFieldUserCore extends ABFieldConnect {
    constructor(values, object) {
       super(values, object, ABFieldUserDefaults);
+
+      this.isUser = true;
+      // {bool}
+      // is this an ABFieldUser type of field.
+      // this is a simplified helper to identify if an ABField is a type
+      // of User field.  Since this is the only place it is defined,
+      // all other field types will be falsy
    }
 
    // return the default values for this DataField


### PR DESCRIPTION
This is the 1st part of the fix for [ns_app#542](https://github.com/digi-serve/ns_app/issues/542)

This also requires this [PR](https://github.com/digi-serve/ab_platform_web/pull/604) as part of the fix.

Here we simply add the property `.isUser` to `ABFieldUser` objects.

## Release Notes
<!-- #release_notes -->
- [wip] include an .isUser property on ABFieldUser objects
<!-- /release_notes --> 

