### PR TITLE
Update support views added from a plugin

### DIFF
--- a/ABViewManagerCore.js
+++ b/ABViewManagerCore.js
@@ -118,11 +118,13 @@ module.exports = class ABViewManagerCore {
       //		if ((values.key) && (Views[values.key])) {
       if (values.key) {
          if (!Views[values.key]) {
-            console.error(
-               "!! View[" +
-                  values.key +
-                  "] not yet defined.  Have an ABView instead:"
-            );
+            if (!isPlugin(values.key)) {
+               console.error(
+                  "!! View[" +
+                     values.key +
+                     "] not yet defined.  Have an ABView instead:"
+               );
+            }
             return new Views["view"](values, application, parent);
          }
 
@@ -146,4 +148,15 @@ module.exports = class ABViewManagerCore {
       console.error(`Unknown View Key[${key}]`);
       return;
    }
+
+   static addViewClass(View) {
+      Views[View.common().key] = View;
+   }
 };
+
+/**
+ * Check if the key starts with plugin_
+ */
+function isPlugin(key) {
+   return key.split("_")[0] === "plugin";
+}


### PR DESCRIPTION
https://github.com/digi-serve/planning/issues/572

As we're moving closer to HR Teams release, I want to move away from needing to maintain different branches and building manually. I packaged the HR Teams Complex Widget as a plugin, in the style of ABDesigner. But this requires modification to ABDesigner, platform_web and core to load the relevant classes. 

See the plugin code here: https://github.com/digi-serve/plugin_HRTeams

The main goal is code separation. I still think we need to work on a more accessible plugin system, that simplifies adding custom features to the platform.

## Release Notes
<!-- #release_notes -->
- Allow custom views to be added by a plugin
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
