### PR TITLE
Fix missing Date conditions checks

### DIFF
--- a/FilterComplexCore.js
+++ b/FilterComplexCore.js
@@ -327,6 +327,12 @@ module.exports = class FilterComplexCore extends ABComponent {
          case "is_not_empty":
             result = !!value;
             break;
+         case "is_null":
+            result = value == null;
+            break;
+         case "is_not_null":
+            result = value != null;
+            break;
          default:
             result = this.queryFieldValid(value, rule, compareValue);
             break;


### PR DESCRIPTION

Just saw this while debugging the HR Team plugin.

## Release Notes
<!-- #release_notes -->
- [fix] missing condition check for date operations
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
