### PR TITLE
Fix the Netsuite IDs as string bug

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1981,8 +1981,10 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      });
                      Promise.all(prmsAllRefreshes).then(() => {
                         allAdds.forEach((d) => {
-                           if (!this.__dataCollection.exists(d[PK])) {
-                              this.__dataCollection.add(d);
+                           if (this.isValidData(d)) {
+                              if (!this.__dataCollection.exists(d[PK])) {
+                                 this.__dataCollection.add(d);
+                              }
                            }
                         });
                      });

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1958,6 +1958,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      let prmsAllRefreshes = [];
                      let allAdds = [];
                      (valuesToAdd || []).forEach((v) => {
+                        // NOTE: it would make sense to perform this check here,
+                        // however some of the values in valuesToAdd may not be
+                        // fully populated, and that could effect our filter checks.
+                        // so we will have to pull all possible rows back, and check
+                        // once they are all loaded (and populated).
+                        // if (!this.isValidData(v)) return;
                         let cond = { where: {} };
                         cond.where[PK] = v;
                         // NOTE: we are using the abbreviated condition syntax here.

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1958,12 +1958,6 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      let prmsAllRefreshes = [];
                      let allAdds = [];
                      (valuesToAdd || []).forEach((v) => {
-                        // NOTE: it would make sense to perform this check here,
-                        // however some of the values in valuesToAdd may not be
-                        // fully populated, and that could effect our filter checks.
-                        // so we will have to pull all possible rows back, and check
-                        // once they are all loaded (and populated).
-                        // if (!this.isValidData(v)) return;
                         let cond = { where: {} };
                         cond.where[PK] = v;
                         // NOTE: we are using the abbreviated condition syntax here.

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1951,24 +1951,41 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
                      // then we have to ask for the values we need to add:
                      valuesToAdd = Object.keys(valuesToAdd); // convert to []
-                     if (valuesToAdd.length > 0) {
+                     // NOTE: .staleRefresh() is designed to handle a single requst
+                     // that will be compiled with other requests to be more efficient
+                     // so we need to make 1 .staleRefresh() at a time and then
+                     // compile those results into our data collection.
+                     let prmsAllRefreshes = [];
+                     let allAdds = [];
+                     (valuesToAdd || []).forEach((v) => {
                         let cond = { where: {} };
-                        cond.where[PK] = valuesToAdd;
+                        cond.where[PK] = v;
                         // NOTE: we are using the abbreviated condition syntax here.
 
                         // NOTE: staleRefresh() has some buffering capabilities
                         // that combine multiple calls into 1 more efficient call:
-                        this.model.staleRefresh(cond).then((res) => {
-                           // check to make sure there is data to work with
-                           if (Array.isArray(res.data) && res.data.length) {
-                              res.data.forEach((d) => {
-                                 if (!this.__dataCollection.exists(d[PK])) {
-                                    this.__dataCollection.add(d);
+                        prmsAllRefreshes.push(
+                           this.model.staleRefresh(cond).then((res) => {
+                              // check to make sure there is data to work with
+                              if (Array.isArray(res.data) && res.data.length) {
+                                 res.data.forEach((d) => {
+                                    allAdds.push(d);
+                                 });
+                              } else {
+                                 if (res.data) {
+                                    allAdds.push(res.data);
                                  }
-                              });
+                              }
+                           })
+                        );
+                     });
+                     Promise.all(prmsAllRefreshes).then(() => {
+                        allAdds.forEach((d) => {
+                           if (!this.__dataCollection.exists(d[PK])) {
+                              this.__dataCollection.add(d);
                            }
                         });
-                     }
+                     });
                   }
 
                   return;

--- a/FilterComplexCore.js
+++ b/FilterComplexCore.js
@@ -558,20 +558,30 @@ module.exports = class FilterComplexCore extends ABComponent {
 
       let connectedVal = "";
 
+      let linkType = field.linkType();
+
       if (rowData) {
          if (rowData[relationName]) {
-            connectedVal = (
-               (field.indexField
-                  ? rowData[relationName][field.indexField.columnName]
-                  : null) ?? // custom index
-               (field.indexField2
-                  ? rowData[relationName][field.indexField2.columnName]
-                  : null) ?? // custom index 2
-               rowData[relationName].id ??
-               rowData[relationName]
-            )
-               .toString()
-               .toLowerCase();
+            if (linkType == "many") {
+               // lets get an array of connected ids => stringified()
+               connectedVal = JSON.stringify(
+                  getConnectFieldValue(rowData, field).map((i) => i.id || i)
+               );
+            } else {
+               // connectedVal = (
+               //    (field.indexField
+               //       ? rowData[relationName][field.indexField.columnName]
+               //       : null) ?? // custom index
+               //    (field.indexField2
+               //       ? rowData[relationName][field.indexField2.columnName]
+               //       : null) ?? // custom index 2
+               //    rowData[relationName].id ??
+               //    rowData[relationName]
+               // )
+               connectedVal = getConnectFieldValue(rowData, field)
+                  .toString()
+                  .toLowerCase();
+            }
          } else {
             let fieldVal = getFieldVal(rowData, field);
             if (fieldVal != null) {
@@ -601,7 +611,21 @@ module.exports = class FilterComplexCore extends ABComponent {
             ? compareValue.toLowerCase?.()
             : compareValue;
 
-      switch (rule) {
+      // NOTE: if linkType == many, and rule is equals/not_equal,
+      // these will be interpreted as "contains/not_contains"
+      let ruleSafe = rule;
+      if (linkType == "many") {
+         switch (rule) {
+            case "equals":
+               ruleSafe = "contains";
+               break;
+            case "not_equal":
+               ruleSafe = "not_contains";
+               break;
+         }
+      }
+
+      switch (ruleSafe) {
          case "contains":
             return connectedVal.toString().indexOf(compareValueLowercase) > -1;
          case "not_contains":


### PR DESCRIPTION
The .staleRefresh() routine used in the `cursorStale` handler of the DataCollection was sending an array of IDs in a single call.

However the actual implementation of .staleRefresh() really only works for a single ID value at a time.

So I rewrote the `cursorStale` to make the call with each value individually and then compile the results and update them afterwards.


## Release Notes
<!-- #release_notes -->
- [fix] make sure we are sending a single ID value on each call to .staleRefresh()
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
