### PR TITLE
Improved csvPack routine

### DIFF
--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -765,11 +765,12 @@ module.exports = class ABModelCore {
       let keys = ["list", "json"];
       let stringifyFields = myObject.fields((f) => keys.indexOf(f.key) > -1);
       stringifyFields.forEach((f) => {
-         content.forEach((row) => {
+         for (let I = 0; I < content.length; I++) {
+            let row = content[I];
             if (row[f.columnName]) {
                row[f.columnName] = JSON.stringify(row[f.columnName]);
             }
-         });
+         }
       });
 
       // break out and compact the connected data
@@ -780,7 +781,8 @@ module.exports = class ABModelCore {
          let connPK = connField.datasourceLink.PK();
 
          // gather all the connected data for this field
-         content.forEach((row) => {
+         for (let I = 0; I < content.length; I++) {
+            let row = content[I];
             if (row[relationName]) {
                if (Array.isArray(row[relationName])) {
                   row[relationName].forEach((r) => {
@@ -795,7 +797,7 @@ module.exports = class ABModelCore {
                   }
                }
             }
-         });
+         }
 
          // assign a smaller id value
          Object.keys(connHash).forEach((id, indx) => {
@@ -803,7 +805,8 @@ module.exports = class ABModelCore {
          });
 
          // now reencode the connection data to reference the new _csvID
-         content.forEach((row) => {
+         for (let I = 0; I < content.length; I++) {
+            let row = content[I];
             let ids = [];
             let hasRelationData = false;
             if (row[relationName]) {
@@ -822,7 +825,7 @@ module.exports = class ABModelCore {
                row[connField.columnName] = JSON.stringify(ids);
                delete row[relationName];
             }
-         });
+         }
 
          let connData = Object.values(connHash);
          connData.forEach((c) => {
@@ -840,7 +843,8 @@ module.exports = class ABModelCore {
       });
 
       // final data preparations for csv encoding
-      content.forEach((row) => {
+      for (let I = 0; I < content.length; I++) {
+         let row = content[I];
          // client side .normalizeData() should repopulate .id
          delete row.id;
 
@@ -859,7 +863,7 @@ module.exports = class ABModelCore {
                delete row[relationName];
             }
          });
-      });
+      }
 
       // now convert the data to CSV
       packedData.data = this.AB.jsonToCsv(content);


### PR DESCRIPTION
In my attempts to improve the performance of our csvPack() routines for large datasets, I've made these changes.

## Release Notes
<!-- #release_notes -->
- [wip] make csvPack() for efficient by replacing .forEach with for()
<!-- /release_notes --> 

## Test Status
Our existing tests should be sufficient for determining if this routine is working.
