### PR TITLE
Pull out where calculation to be reusable

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -2137,28 +2137,20 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
    //    return null;
    // }
 
-   async loadData(start, limit) {
-      // mark data status is initializing
-      if (this._dataStatus == this.dataStatusFlag.notInitial) {
-         this._dataStatus = this.dataStatusFlag.initializing;
-         this.emit("initializingData", {});
-      }
-
-      var obj = this.datasource;
-      if (obj == null) {
-         this._dataStatus = this.dataStatusFlag.initialized;
-         return Promise.resolve([]);
-      }
-
-      var model = obj.model();
-      if (model == null) {
-         this._dataStatus = this.dataStatusFlag.initialized;
-         return Promise.resolve([]);
-      }
-
-      // pull the defined sort values
-      var sorts = this.settings.objectWorkspace.sortFields || [];
-
+   /**
+    * @method getWhereClause()
+    * Return the current where condition for the datacollection.
+    * The where condition might change depending if we are following
+    * another datacollection or not.
+    *
+    * NOTE: start and limit might be effected by some of our settings
+    * so we include them here and then return those values as well.
+    *
+    * @param {int} start
+    * @param {int} limit
+    * @returns [ wheres, start, limit ]
+    */
+   getWhereClause(start, limit) {
       // pull filter conditions
       let wheres = this.AB.cloneDeep(
          this.settings.objectWorkspace.filterConditions ?? {}
@@ -2235,7 +2227,114 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
       // remove any null in the .rules
       // if (wheres?.rules?.filter) wheres.rules = wheres.rules.filter((r) => r);
-      wheres = obj.whereCleanUp(wheres);
+      wheres = this.datasource.whereCleanUp(wheres);
+
+      return [wheres, start, limit];
+   }
+
+   async loadData(start, limit) {
+      // mark data status is initializing
+      if (this._dataStatus == this.dataStatusFlag.notInitial) {
+         this._dataStatus = this.dataStatusFlag.initializing;
+         this.emit("initializingData", {});
+      }
+
+      var obj = this.datasource;
+      if (obj == null) {
+         this._dataStatus = this.dataStatusFlag.initialized;
+         return Promise.resolve([]);
+      }
+
+      var model = obj.model();
+      if (model == null) {
+         this._dataStatus = this.dataStatusFlag.initialized;
+         return Promise.resolve([]);
+      }
+
+      // pull the defined sort values
+      var sorts = this.settings.objectWorkspace.sortFields || [];
+
+      let [wheres, s2, l2] = this.getWhereClause(start, limit);
+      start = s2;
+      limit = l2;
+
+      // // pull filter conditions
+      // let wheres = this.AB.cloneDeep(
+      //    this.settings.objectWorkspace.filterConditions ?? {}
+      // );
+      // // if we pass new wheres with a reload use them instead
+      // if (this.__reloadWheres) {
+      //    wheres = this.__reloadWheres;
+      // }
+      // wheres.glue = wheres.glue || "and";
+      // wheres.rules = wheres.rules || [];
+
+      // const __additionalWheres = {
+      //    glue: "and",
+      //    rules: [],
+      // };
+
+      // // add the filterCond if there are rules to add
+      // if (this.__filterCond?.rules?.length > 0) {
+      //    __additionalWheres.rules.push(this.__filterCond);
+      // }
+
+      // // Filter by a selected cursor of a link DC
+      // let linkRule = this.ruleLinkedData();
+      // if (!this.settings.loadAll && linkRule) {
+      //    __additionalWheres.rules.push(linkRule);
+      // }
+      // // pull data rows following the follow data collection
+      // else if (this.datacollectionFollow) {
+      //    const followCursor = this.datacollectionFollow.getCursor();
+      //    // store the PK as a variable
+      //    let PK = this.datasource.PK();
+      //    // if the datacollection we are following is a query
+      //    // add "BASE_OBJECT." to the PK so we can select the
+      //    // right value to report the cursor change to
+      //    if (this.datacollectionFollow.settings.isQuery) {
+      //       PK = "BASE_OBJECT." + PK;
+      //    }
+      //    if (followCursor) {
+      //       start = 0;
+      //       limit = null;
+      //       wheres = {
+      //          glue: "and",
+      //          rules: [
+      //             {
+      //                key: this.datasource.PK(),
+      //                rule: "equals",
+      //                value: followCursor[PK],
+      //             },
+      //          ],
+      //       };
+      //    }
+      //    // Set no return rows
+      //    else {
+      //       wheres = {
+      //          glue: "and",
+      //          rules: [
+      //             {
+      //                key: this.datasource.PK(),
+      //                rule: "equals",
+      //                value: "NO RESULT ROW",
+      //             },
+      //          ],
+      //       };
+      //    }
+      // }
+
+      // // Combine setting & program filters
+      // if (__additionalWheres.rules.length) {
+      //    if (wheres.rules.length) {
+      //       __additionalWheres.rules.unshift(wheres);
+      //    }
+      //    wheres = __additionalWheres;
+      // }
+
+      // // remove any null in the .rules
+      // // if (wheres?.rules?.filter) wheres.rules = wheres.rules.filter((r) => r);
+      // wheres = obj.whereCleanUp(wheres);
 
       // set query condition
       var cond = {


### PR DESCRIPTION
Adding code in ab_platform_web to prevent duplicate loadData() requests, but need to access the where condition there too.

So I am pulling out the where clause generation so I can use it in multiple places.

## Release Notes
<!-- #release_notes -->
- [wip] pull the where condition calculation out of loadData() so we can use it in other places too
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
