### PR TITLE
csvPack now packs data deeply

### DIFF
--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -732,7 +732,7 @@ module.exports = class ABModelCore {
     *                  total_bytes:xx,
     *                }
     */
-   csvPack(data) {
+   csvPackOld(data) {
       // data should be the original json data packet we want to send
       // {
       //   data: [{obj1}, {obj2}, ... {objN}],
@@ -758,10 +758,12 @@ module.exports = class ABModelCore {
       // Note: CSV will refer to the columns at the first row in a list to generate CSV columns.
       // if the first row were missing somecolumns and the next rows has those columns.
       // they will lost those columns and values
-      if(firstRow) {
-        const columnNames = Object.keys(firstRow);
-        for (const missingField of myObject.fields(f => columnNames.indexOf(f.columnName) === -1))
-           firstRow[missingField.columnName] = undefined;
+      if (firstRow) {
+         const columnNames = Object.keys(firstRow);
+         for (const missingField of myObject.fields(
+            (f) => columnNames.indexOf(f.columnName) === -1
+         ))
+            firstRow[missingField.columnName] = undefined;
       }
       let returnType = "array";
       if (!Array.isArray(content)) {
@@ -891,6 +893,220 @@ module.exports = class ABModelCore {
       return newData;
    }
 
+   csvPackPrepareFirstRow(myObject, content) {
+      const firstRow = content[0];
+
+      // Note: CSV will refer to the columns at the first row in a list to generate CSV columns.
+      // if the first row were missing somecolumns and the next rows has those columns.
+      // they will lost those columns and values
+      if (firstRow) {
+         const columnNames = Object.keys(firstRow);
+         for (const missingField of myObject.fields(
+            (f) => columnNames.indexOf(f.columnName) === -1
+         ))
+            firstRow[missingField.columnName] = undefined;
+      }
+   }
+
+   csvPackStringifyFields(myObject, content) {
+      // stringify any potential json data
+      // starting with List data
+      let keys = ["list", "json"];
+      let stringifyFields = myObject.fields((f) => keys.indexOf(f.key) > -1);
+      stringifyFields.forEach((f) => {
+         for (let I = 0; I < content.length; I++) {
+            let row = content[I];
+            if (row[f.columnName]) {
+               row[f.columnName] = JSON.stringify(row[f.columnName]);
+            }
+         }
+      });
+   }
+
+   csvPackGetRelations(myObject, content) {
+      let relations = {
+         /* objectID: { row.id: entryJSON} */
+      };
+
+      // break out and compact the connected data
+      let connections = myObject.connectFields();
+      connections.forEach((connField) => {
+         let connHash = {};
+         let relationName = connField.relationName();
+         let connPK = connField.datasourceLink.PK();
+
+         // gather all the connected data for this field
+         for (let I = 0; I < content.length; I++) {
+            let row = content[I];
+            if (row[relationName]) {
+               if (Array.isArray(row[relationName])) {
+                  row[relationName].forEach((r) => {
+                     if (!connHash[r.id]) {
+                        connHash[r.id] = r;
+                     }
+                  });
+               } else {
+                  let r = row[relationName];
+                  if (!connHash[r.id]) {
+                     connHash[r.id] = r;
+                  }
+               }
+            }
+         }
+
+         let connObject = connField.datasourceLink;
+         let values = Object.values(connHash);
+
+         relations[connObject.id] = connHash;
+
+         let connRelations = this.csvPackGetRelations(connObject, values);
+
+         // merge these into my relations
+         Object.keys(connRelations).forEach((id) => {
+            if (!relations[id]) {
+               relations[id] = connRelations[id];
+            } else {
+               Object.keys(connRelations[id]).forEach((cid) => {
+                  if (!relations[id][cid]) {
+                     relations[id][cid] = connRelations[id][cid];
+                  } else {
+                     // make sure we add any new fields from conn to relations
+                     // hopefully this is just adding a __relation value that wasn't
+                     // already there.
+                     Object.keys(connRelations[id][cid]).forEach((key) => {
+                        if (!relations[id][cid][key]) {
+                           relations[id][cid][key] =
+                              connRelations[id][cid][key];
+                        }
+                     });
+                  }
+               });
+            }
+         });
+      });
+   }
+
+   csvPackReIndexRelations(relations) {
+      Object.keys(relations).forEach((id) => {
+         Object.keys(relations[id]).forEach((cid, indx) => {
+            relations[id][cid]._csvID = indx;
+         });
+      });
+   }
+
+   csvPackReEncodeRelations(relations, myObject, content) {
+      let connections = myObject.connectFields();
+      connections.forEach((connField) => {
+         let relationName = connField.relationName();
+         let connObject = connField.datasourceLink;
+         let connHash = relations[connObject.id];
+
+         // now reencode the connection data to reference the new _csvID
+         for (let I = 0; I < content.length; I++) {
+            let row = content[I];
+            let ids = [];
+            let hasRelationData = false;
+            if (row[relationName]) {
+               hasRelationData = true;
+               if (Array.isArray(row[relationName])) {
+                  row[relationName].forEach((r) => {
+                     ids.push(connHash[r.id]._csvID);
+                  });
+               } else {
+                  let r = row[relationName];
+                  ids.push(connHash[r.id]._csvID);
+               }
+            }
+            // only make an update if it did have relation data
+            if (hasRelationData) {
+               row[connField.columnName] = JSON.stringify(ids);
+               delete row[relationName];
+            }
+         }
+      });
+   }
+
+   csvPackFinalModifications(myObject, content) {
+      let connPK = myObject.PK();
+      const isPKID = connPK === "id";
+      content.forEach((c) => {
+         if (!isPKID && c.id == c[connPK]) {
+            delete c.id;
+         }
+
+         // if translations are present return them to an object
+         if (c.translations && typeof c.translations != "string") {
+            c.translations = JSON.stringify(c.translations);
+         }
+      });
+   }
+
+   csvPack(data) {
+      // data should be the original json data packet we want to send
+      // {
+      //   data: [{obj1}, {obj2}, ... {objN}],
+      //   total_bytes:xx,
+      // }
+      // we want to convert this to:
+      // {
+      //   csv_packed:{
+      //     data: "csv data",
+      //     relations: {
+      //       {connectionID}: "csv data", // each entry has entry._csvID, that is the lookup
+      //       {connectionID}: "csv data",
+      //       ...
+      //   }
+      //   total_bytes:xx,
+      // }
+      let packedData = { data: "", relations: {} };
+      let myObject = this.object;
+
+      let content = data.data;
+
+      this.csvPackPrepareFirstRow(myObject, content);
+
+      let returnType = "array";
+      if (!Array.isArray(content)) {
+         returnType = "single";
+         content = [content];
+      }
+      content = content.filter((row) => !this.AB.isNil(row));
+
+      this.csvPackStringifyFields(myObject, content);
+
+      let relations = this.csvPackGetRelations(myObject, content);
+      // { objectID: { row.id: entryJSON}}
+
+      this.csvPackReIndexRelations(relations);
+
+      // now reencode the connection data to reference the new _csvID
+      // do this for the main content
+      this.csvPackReEncodeRelations(relations, myObject, content);
+      this.csvPackFinalModifications(myObject, content);
+
+      // do this for the relations as well
+      Object.keys(relations).forEach((id) => {
+         let relatedObj = this.AB.objectById(id);
+         let values = Object.values(relations[id]);
+         this.csvPackReEncodeRelations(relations, relatedObj, values);
+         this.csvPackFinalModifications(relatedObj, values);
+         packedData.relations[id] = this.AB.jsonToCsv(values);
+      });
+
+      // now convert the data to CSV
+      packedData.data = this.AB.jsonToCsv(content);
+      packedData.type = returnType; // single or array
+
+      let newData = {};
+      Object.keys(data).forEach((key) => {
+         if (key != "data") {
+            newData[key] = data[key];
+         }
+      });
+      newData.csv_packed = packedData;
+      return newData;
+   }
+
    /**
     * @method csvUnpack
     * unpack the data from our csv format
@@ -898,7 +1114,7 @@ module.exports = class ABModelCore {
     *              The csv packed data format.
     * @return {json} the unpacked data
     */
-   csvUnpack(data) {
+   csvUnpackOld(data) {
       // data should be a data packet returned from the server
       // {
       //   csv_packed:{
@@ -1043,6 +1259,201 @@ module.exports = class ABModelCore {
             }
          });
       });
+
+      let returnData = {};
+      Object.keys(data).forEach((key) => {
+         if (key != "csv_packed") {
+            returnData[key] = data[key];
+         }
+      });
+      returnData.data = jsonData;
+
+      if (returnType == "single" && Array.isArray(returnData.data)) {
+         returnData.data = returnData.data[0];
+      }
+      return returnData;
+   }
+
+   csvUnpackUnstringifyFields(myObject, data) {
+      let connPK = myObject.PK();
+      let keyFields = ["list", "boolean", "number", "json"];
+      let parseFields = myObject.fields((f) => keyFields.indexOf(f.key) > -1);
+      data.forEach((row) => {
+         // unstringify any list,bool,number fields
+         parseFields.forEach((f) => {
+            let val = row[f.columnName];
+            if (val && typeof val == "string") {
+               try {
+                  row[f.columnName] = JSON.parse(val);
+               } catch (e) {
+                  console.error(
+                     "Error parsing JSON data for column: " + f.columnName,
+                     val,
+                     e
+                  );
+               }
+            }
+         });
+
+         // if translations are present return them to an object
+         if (row.translations) {
+            row.translations = JSON.parse(row.translations);
+         }
+
+         // readd .id to the row
+         if (!row.id) {
+            row.id = row[connPK];
+         }
+      });
+   }
+
+   csvUnpackReconnectRelations(relations, myObject, data) {
+      let connections = myObject.connectFields();
+      connections.forEach((connField) => {
+         let relationName = connField.relationName();
+
+         let relationObject = connField.datasourceLink;
+         let connHash = relations[relationObject.id];
+         if (connHash) {
+            data.forEach((row) => {
+               let ids = [];
+               let populatedData = [];
+               let entries = [];
+               try {
+                  // ok, we know this is a possibility, so just skip it
+                  if (row[connField.columnName] !== "") {
+                     entries = JSON.parse(row[connField.columnName]);
+                  }
+               } catch (e) {
+                  if (row[connField.columnName] == "") {
+                     // not a problem, just no data
+                  } else {
+                     // this might be a situation on the server where
+                     // row[columnName] has a value, but row[relationName] is empty.
+                     if (typeof row[relationName] == "undefined") {
+                        row[relationName] = null;
+                     }
+                     // console.error(
+                     //    "Error parsing JSON data for column: " +
+                     //       connField.columnName,
+                     //    e
+                     // );
+                  }
+               }
+               if (!Array.isArray(entries)) {
+                  entries = [entries];
+               }
+               entries.forEach((id) => {
+                  if (connHash[id]) {
+                     let connEntry = connHash[id];
+                     ids.push(connField.getRelationValue(connEntry));
+                     // Alternatively, we could remove the row[columnName] and let
+                     // normalizeData() repopulate it.
+                     populatedData.push(connEntry);
+                  }
+               });
+               if (connField.linkType() == "many") {
+                  row[connField.columnName] = ids;
+                  row[connField.relationName()] = populatedData;
+               } else {
+                  row[connField.columnName] = ids[0];
+                  row[connField.relationName()] = populatedData[0];
+               }
+            });
+         }
+      });
+
+      // final pass to clear up stringified relation data
+      data.forEach((row) => {
+         connections.forEach((connField) => {
+            // many connections must be an array, not "[]"
+            if (connField.linkType() == "many") {
+               let val = row[connField.columnName];
+               if (val && typeof val == "string") {
+                  row[connField.columnName] = JSON.parse(val);
+               }
+            }
+         });
+      });
+   }
+
+   csvUnpackClearCSVID(relations) {
+      Object.keys(relations).forEach((id) => {
+         Object.keys(relations[id]).forEach((cid) => {
+            delete relations[id][cid]._csvID;
+         });
+      });
+   }
+
+   /**
+    * @method csvUnpackDeep
+    * unpack the data from our csv format
+    * @param {json} data
+    *              The csv packed data format.
+    * @return {json} the unpacked data
+    */
+   csvUnpack(data) {
+      // data should be a data packet returned from the server
+      // {
+      //   csv_packed:{
+      //     data: "csv data",
+      //     relations: {
+      //       {connectionID}: "csv data", // each entry has entry._csvID, that is the lookup
+      //       {connectionID}: "csv data",
+      //       ...
+      //   }
+      //   total_bytes:xx,
+      // }
+      // we want to convert this to:
+      // {
+      //   data: [{obj1}, {obj2}, ... {objN}],
+      //   total_bytes:xx,
+      // }
+
+      let myObject = this.object;
+      let parseResult = this.AB.csvToJson(data.csv_packed.data);
+      // parseResult = { data: [], errors:[], meta:{}}
+
+      let returnType = data.csv_packed.type;
+
+      if (parseResult.errors?.length) {
+         // ignore common error when .data is ""
+         if (data.csv_packed.data !== "") {
+            console.error("Error parsing CSV data:", parseResult.errors);
+            console.error("Original CSV data:");
+            console.error(data.csv_packed.data);
+            console.error("result:");
+            console.error(parseResult.data);
+         }
+      }
+      let jsonData = parseResult.data;
+
+      let relations = {};
+      Object.keys(data.csv_packed.relations).forEach((id) => {
+         relations[id] = this.AB.csvToJson(data.csv_packed.relations[id]).data;
+      });
+
+      this.csvUnpackUnstringifyFields(myObject, jsonData);
+      Object.keys(relations).forEach((id) => {
+         this.csvUnpackUnstringifyFields(this.AB.objectById(id), relations[id]);
+         // to hash by _csvID
+         let hash = {};
+         relations[id].forEach((c) => {
+            hash[c._csvID] = c;
+         });
+         relations[id] = hash;
+      });
+
+      // now reconnect the data
+      Object.keys(relations).forEach((id) => {
+         let relatedObj = this.AB.objectById(id);
+         let values = Object.values(relations[id]);
+         this.csvUnpackReconnectRelations(relations, relatedObj, values);
+      });
+
+      this.csvUnpackReconnectRelations(myObject, jsonData);
+
+      this.csvUnpackClearCSVID(relations);
 
       let returnData = {};
       Object.keys(data).forEach((key) => {

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -1307,7 +1307,9 @@ module.exports = class ABModelCore {
 
          // readd .id to the row
          if (!row.id) {
-            row.id = row[connPK];
+            if (row[connPK]) {
+               row.id = row[connPK];
+            }
          }
       });
    }
@@ -1324,45 +1326,47 @@ module.exports = class ABModelCore {
                let ids = [];
                let populatedData = [];
                let entries = [];
-               try {
-                  // ok, we know this is a possibility, so just skip it
-                  if (row[connField.columnName] !== "") {
-                     entries = JSON.parse(row[connField.columnName]);
-                  }
-               } catch (e) {
-                  if (row[connField.columnName] == "") {
-                     // not a problem, just no data
-                  } else {
-                     // this might be a situation on the server where
-                     // row[columnName] has a value, but row[relationName] is empty.
-                     if (typeof row[relationName] == "undefined") {
-                        row[relationName] = null;
+               if (typeof row[connField.columnName] !== "undefined") {
+                  try {
+                     // ok, we know this is a possibility, so just skip it
+                     if (row[connField.columnName] !== "") {
+                        entries = JSON.parse(row[connField.columnName]);
                      }
-                     // console.error(
-                     //    "Error parsing JSON data for column: " +
-                     //       connField.columnName,
-                     //    e
-                     // );
+                  } catch (e) {
+                     if (row[connField.columnName] == "") {
+                        // not a problem, just no data
+                     } else {
+                        // this might be a situation on the server where
+                        // row[columnName] has a value, but row[relationName] is empty.
+                        if (typeof row[relationName] == "undefined") {
+                           row[relationName] = null;
+                        }
+                        // console.error(
+                        //    "Error parsing JSON data for column: " +
+                        //       connField.columnName,
+                        //    e
+                        // );
+                     }
                   }
-               }
-               if (!Array.isArray(entries)) {
-                  entries = [entries];
-               }
-               entries.forEach((id) => {
-                  if (connHash[id]) {
-                     let connEntry = connHash[id];
-                     ids.push(connField.getRelationValue(connEntry));
-                     // Alternatively, we could remove the row[columnName] and let
-                     // normalizeData() repopulate it.
-                     populatedData.push(connEntry);
+                  if (!Array.isArray(entries)) {
+                     entries = [entries];
                   }
-               });
-               if (connField.linkType() == "many") {
-                  row[connField.columnName] = ids;
-                  row[connField.relationName()] = populatedData;
-               } else {
-                  row[connField.columnName] = ids[0];
-                  row[connField.relationName()] = populatedData[0];
+                  entries.forEach((id) => {
+                     if (connHash[id]) {
+                        let connEntry = connHash[id];
+                        ids.push(connField.getRelationValue(connEntry));
+                        // Alternatively, we could remove the row[columnName] and let
+                        // normalizeData() repopulate it.
+                        populatedData.push(connEntry);
+                     }
+                  });
+                  if (connField.linkType() == "many") {
+                     row[connField.columnName] = ids;
+                     row[connField.relationName()] = populatedData;
+                  } else {
+                     row[connField.columnName] = ids[0] ?? null;
+                     row[connField.relationName()] = populatedData[0] ?? null;
+                  }
                }
             });
          }
@@ -1456,7 +1460,7 @@ module.exports = class ABModelCore {
          this.csvUnpackReconnectRelations(relations, relatedObj, values);
       });
 
-      this.csvUnpackReconnectRelations(myObject, jsonData);
+      this.csvUnpackReconnectRelations(relations, myObject, jsonData);
 
       this.csvUnpackClearCSVID(relations);
 

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -941,14 +941,14 @@ module.exports = class ABModelCore {
                if (Array.isArray(row[relationName])) {
                   row[relationName].forEach((r) => {
                      let rval = connField.getRelationValue(r);
-                     if (!connHash[rval]) {
+                     if (rval != null && !connHash[rval]) {
                         connHash[rval] = r;
                      }
                   });
                } else {
                   let r = row[relationName];
                   let rval = connField.getRelationValue(r);
-                  if (!connHash[rval]) {
+                  if (rval != null && !connHash[rval]) {
                      connHash[rval] = r;
                   }
                }
@@ -1014,12 +1014,24 @@ module.exports = class ABModelCore {
                if (Array.isArray(row[relationName])) {
                   row[relationName].forEach((r) => {
                      let rval = connField.getRelationValue(r);
-                     ids.push(connHash[rval]._csvID);
+                     if (
+                        rval != null &&
+                        connHash[rval] &&
+                        connHash[rval]._csvID != null
+                     ) {
+                        ids.push(connHash[rval]._csvID);
+                     }
                   });
                } else {
                   let r = row[relationName];
                   let rval = connField.getRelationValue(r);
-                  ids.push(connHash[rval]._csvID);
+                  if (
+                     rval != null &&
+                     connHash[rval] &&
+                     connHash[rval]._csvID != null
+                  ) {
+                     ids.push(connHash[rval]._csvID);
+                  }
                }
             }
             // only make an update if it did have relation data
@@ -1068,6 +1080,10 @@ module.exports = class ABModelCore {
 
       let content = data.data;
 
+      if (!content || (Array.isArray(content) && content.length === 0)) {
+         // Return the original data if there is no content to pack
+         // existing code will handle this fine.
+         return data;
       this.csvPackPrepareFirstRow(myObject, content);
 
       let returnType = "array";
@@ -1090,13 +1106,21 @@ module.exports = class ABModelCore {
       this.csvPackFinalModifications(myObject, content);
 
       // do this for the relations as well
-      Object.keys(relations).forEach((id) => {
+      let allIds = Object.keys(relations);
+      for (let i = 0; i < allIds.length; i++) {
+         let id = allIds[i];
          let relatedObj = this.AB.objectByID(id);
-         let values = Object.values(relations[id]);
-         this.csvPackReEncodeRelations(relations, relatedObj, values);
-         this.csvPackFinalModifications(relatedObj, values);
-         packedData.relations[id] = this.AB.jsonToCsv(values);
-      });
+         if (relatedObj) {
+            let values = Object.values(relations[id]);
+            this.csvPackReEncodeRelations(relations, relatedObj, values);
+            this.csvPackFinalModifications(relatedObj, values);
+            packedData.relations[id] = await this.AB.jsonToCsvBatched(
+               values,
+               batchSize,
+               jobID
+            );
+         }
+      }
 
       // now convert the data to CSV
       packedData.data = this.AB.jsonToCsv(content);
@@ -1302,7 +1326,11 @@ module.exports = class ABModelCore {
 
          // if translations are present return them to an object
          if (row.translations) {
-            row.translations = JSON.parse(row.translations);
+            try {
+               row.translations = JSON.parse(row.translations);
+            } catch (e) {
+               // just leave it as it is
+            }
          }
 
          // readd .id to the row
@@ -1352,12 +1380,16 @@ module.exports = class ABModelCore {
                      entries = [entries];
                   }
                   entries.forEach((id) => {
-                     if (connHash[id]) {
+                     if (id != null && connHash[id]) {
                         let connEntry = connHash[id];
                         ids.push(connField.getRelationValue(connEntry));
                         // Alternatively, we could remove the row[columnName] and let
                         // normalizeData() repopulate it.
                         populatedData.push(connEntry);
+                     } else if (id != null) {
+                        console.warn(
+                           `Missing relation entry for _csvID: ${id}`
+                        );
                      }
                   });
                   if (connField.linkType() == "many") {
@@ -1395,7 +1427,7 @@ module.exports = class ABModelCore {
    }
 
    /**
-    * @method csvUnpackDeep
+    * @method csvUnpack
     * unpack the data from our csv format
     * @param {json} data
     *              The csv packed data format.
@@ -1418,6 +1450,12 @@ module.exports = class ABModelCore {
       //   data: [{obj1}, {obj2}, ... {objN}],
       //   total_bytes:xx,
       // }
+      if (!data || !data.csv_packed) {
+         throw new Error("csvUnpack: Invalid data format - csv_packed missing");
+      }
+      if (typeof data.csv_packed.data !== "string") {
+         throw new Error("csvUnpack: Invalid csv_packed.data format");
+      }
 
       let myObject = this.object;
       let parseResult = this.AB.csvToJson(data.csv_packed.data);
@@ -1444,20 +1482,25 @@ module.exports = class ABModelCore {
 
       this.csvUnpackUnstringifyFields(myObject, jsonData);
       Object.keys(relations).forEach((id) => {
-         this.csvUnpackUnstringifyFields(this.AB.objectByID(id), relations[id]);
-         // to hash by _csvID
-         let hash = {};
-         relations[id].forEach((c) => {
-            hash[c._csvID] = c;
-         });
-         relations[id] = hash;
+         let relatedObj = this.AB.objectByID(id);
+         if (relatedObj) {
+            this.csvUnpackUnstringifyFields(relatedObj, relations[id]);
+            // to hash by _csvID
+            let hash = {};
+            relations[id].forEach((c) => {
+               hash[c._csvID] = c;
+            });
+            relations[id] = hash;
+         }
       });
 
       // now reconnect the data
       Object.keys(relations).forEach((id) => {
          let relatedObj = this.AB.objectByID(id);
-         let values = Object.values(relations[id]);
-         this.csvUnpackReconnectRelations(relations, relatedObj, values);
+         if (relatedObj) {
+            let values = Object.values(relations[id]);
+            this.csvUnpackReconnectRelations(relations, relatedObj, values);
+         }
       });
 
       this.csvUnpackReconnectRelations(relations, myObject, jsonData);

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -997,11 +997,14 @@ module.exports = class ABModelCore {
                try {
                   row[f.columnName] = JSON.parse(val);
                } catch (e) {
-                  console.error(
-                     "Error parsing JSON data for column: " + f.columnName,
-                     val,
-                     e
-                  );
+                  // sometimes "list" fields are not JSON parseable
+                  if (f.key != "list") {
+                     console.error(
+                        "Error parsing JSON data for column: " + f.columnName,
+                        val,
+                        e
+                     );
+                  }
                }
             }
          });

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -710,189 +710,6 @@ module.exports = class ABModelCore {
       return false;
    }
 
-   /**
-    * @method csvPack
-    * pack the data into a csv format
-    * @param {json} data
-    *               The original data format.
-    *              {
-    *                data: [{obj1}, {obj2}, ... {objN}],
-    *                total_bytes:xx,
-    *              }
-    * @return {json} the csv packed data
-    *                {
-    *                  csv_packed:{
-    *                    data: "<csv data>",
-    *                    relations: {
-    *                      {connectionID}: "<csv data>",
-    *                      {connectionID}: "<csv data>",
-    *                      ...
-    *                    },
-    *                  },
-    *                  total_bytes:xx,
-    *                }
-    */
-   csvPackOld(data) {
-      // data should be the original json data packet we want to send
-      // {
-      //   data: [{obj1}, {obj2}, ... {objN}],
-      //   total_bytes:xx,
-      // }
-      // we want to convert this to:
-      // {
-      //   csv_packed:{
-      //     data: "csv data",
-      //     relations: {
-      //       {connectionID}: "csv data", // each entry has entry._csvID, that is the lookup
-      //       {connectionID}: "csv data",
-      //       ...
-      //   }
-      //   total_bytes:xx,
-      // }
-      let packedData = { data: "", relations: {} };
-      let myObject = this.object;
-
-      let content = data.data;
-      const firstRow = content[0];
-
-      // Note: CSV will refer to the columns at the first row in a list to generate CSV columns.
-      // if the first row were missing somecolumns and the next rows has those columns.
-      // they will lost those columns and values
-      if (firstRow) {
-         const columnNames = Object.keys(firstRow);
-         for (const missingField of myObject.fields(
-            (f) => columnNames.indexOf(f.columnName) === -1
-         ))
-            firstRow[missingField.columnName] = undefined;
-      }
-      let returnType = "array";
-      if (!Array.isArray(content)) {
-         returnType = "single";
-         content = [content];
-      }
-      content = content.filter((row) => !this.AB.isNil(row));
-
-      // stringify any potential json data
-      // starting with List data
-      let keys = ["list", "json"];
-      let stringifyFields = myObject.fields((f) => keys.indexOf(f.key) > -1);
-      stringifyFields.forEach((f) => {
-         for (let I = 0; I < content.length; I++) {
-            let row = content[I];
-            if (row[f.columnName]) {
-               row[f.columnName] = JSON.stringify(row[f.columnName]);
-            }
-         }
-      });
-
-      // break out and compact the connected data
-      let connections = myObject.connectFields();
-      connections.forEach((connField) => {
-         let connHash = {};
-         let relationName = connField.relationName();
-         let connPK = connField.datasourceLink.PK();
-
-         // gather all the connected data for this field
-         for (let I = 0; I < content.length; I++) {
-            let row = content[I];
-            if (row[relationName]) {
-               if (Array.isArray(row[relationName])) {
-                  row[relationName].forEach((r) => {
-                     if (!connHash[r.id]) {
-                        connHash[r.id] = r;
-                     }
-                  });
-               } else {
-                  let r = row[relationName];
-                  if (!connHash[r.id]) {
-                     connHash[r.id] = r;
-                  }
-               }
-            }
-         }
-
-         // assign a smaller id value
-         Object.keys(connHash).forEach((id, indx) => {
-            connHash[id]._csvID = indx;
-         });
-
-         // now reencode the connection data to reference the new _csvID
-         for (let I = 0; I < content.length; I++) {
-            let row = content[I];
-            let ids = [];
-            let hasRelationData = false;
-            if (row[relationName]) {
-               hasRelationData = true;
-               if (Array.isArray(row[relationName])) {
-                  row[relationName].forEach((r) => {
-                     ids.push(connHash[r.id]._csvID);
-                  });
-               } else {
-                  let r = row[relationName];
-                  ids.push(connHash[r.id]._csvID);
-               }
-            }
-            // only make an update if it did have relation data
-            if (hasRelationData) {
-               row[connField.columnName] = JSON.stringify(ids);
-               delete row[relationName];
-            }
-         }
-
-         let connData = Object.values(connHash);
-         const isPKID = connPK === "id";
-         connData.forEach((c) => {
-            if (!isPKID && c.id == c[connPK]) {
-               delete c.id;
-            }
-
-            // if translations are present return them to an object
-            if (c.translations) {
-               c.translations = JSON.stringify(c.translations);
-            }
-         });
-         let connDataCsv = this.AB.jsonToCsv(connData);
-         packedData.relations[connField.id] = connDataCsv;
-      });
-
-      // final data preparations for csv encoding
-      const isPKID = myObject.PK();
-      for (let I = 0; I < content.length; I++) {
-         let row = content[I];
-         // client side .normalizeData() should repopulate .id
-         !isPKID && delete row.id;
-
-         // we don't use .properties anymore, right?
-         delete row.properties;
-
-         // make sure embedded translations are stringified.
-         if (row.translations) {
-            row.translations = JSON.stringify(row.translations);
-         }
-
-         // special case for relations that are empty
-         connections.forEach((connField) => {
-            let relationName = connField.relationName();
-            if (row[relationName] === null) {
-               delete row[relationName];
-            }
-         });
-      }
-
-      // now convert the data to CSV
-      packedData.data = this.AB.jsonToCsv(content);
-      packedData.type = returnType; // single or array
-
-      let newData = {};
-      Object.keys(data).forEach((key) => {
-         if (key != "data") {
-            newData[key] = data[key];
-         }
-      });
-      newData.csv_packed = packedData;
-      return newData;
-   }
-
    csvPackPrepareFirstRow(myObject, content) {
       const firstRow = content[0];
 
@@ -1056,7 +873,29 @@ module.exports = class ABModelCore {
       });
    }
 
-   csvPack(data) {
+   /**
+    * @method csvPack
+    * pack the data into a csv format
+    * @param {json} data
+    *               The original data format.
+    *              {
+    *                data: [{obj1}, {obj2}, ... {objN}],
+    *                total_bytes:xx,
+    *              }
+    * @return {json} the csv packed data
+    *                {
+    *                  csv_packed:{
+    *                    data: "<csv data>",
+    *                    relations: {
+    *                      {connectionID}: "<csv data>",
+    *                      {connectionID}: "<csv data>",
+    *                      ...
+    *                    },
+    *                  },
+    *                  total_bytes:xx,
+    *                }
+    */
+   async csvPack(data, batchSize = 10000, jobID) {
       // data should be the original json data packet we want to send
       // {
       //   data: [{obj1}, {obj2}, ... {objN}],
@@ -1144,173 +983,6 @@ module.exports = class ABModelCore {
       });
       newData.csv_packed = packedData;
       return newData;
-   }
-
-   /**
-    * @method csvUnpack
-    * unpack the data from our csv format
-    * @param {json} data
-    *              The csv packed data format.
-    * @return {json} the unpacked data
-    */
-   csvUnpackOld(data) {
-      // data should be a data packet returned from the server
-      // {
-      //   csv_packed:{
-      //     data: "csv data",
-      //     relations: {
-      //       {connectionID}: "csv data", // each entry has entry._csvID, that is the lookup
-      //       {connectionID}: "csv data",
-      //       ...
-      //   }
-      //   total_bytes:xx,
-      // }
-      // we want to convert this to:
-      // {
-      //   data: [{obj1}, {obj2}, ... {objN}],
-      //   total_bytes:xx,
-      // }
-
-      let myObject = this.object;
-      let parseResult = this.AB.csvToJson(data.csv_packed.data);
-      // parseResult = { data: [], errors:[], meta:{}}
-
-      let returnType = data.csv_packed.type;
-
-      if (parseResult.errors?.length) {
-         // ignore common error when .data is ""
-         if (data.csv_packed.data !== "") {
-            console.error("Error parsing CSV data:", parseResult.errors);
-            console.error("Original CSV data:");
-            console.error(data.csv_packed.data);
-            console.error("result:");
-            console.error(parseResult.data);
-         }
-      }
-      let jsonData = parseResult.data;
-
-      let keyFields = ["list", "boolean", "number", "json"];
-      let parseFields = myObject.fields((f) => keyFields.indexOf(f.key) > -1);
-      jsonData.forEach((row) => {
-         // unstringify any list,bool,number fields
-         parseFields.forEach((f) => {
-            let val = row[f.columnName];
-            if (val && typeof val == "string") {
-               try {
-                  row[f.columnName] = JSON.parse(val);
-               } catch (e) {
-                  console.error(
-                     "Error parsing JSON data for column: " + f.columnName,
-                     val,
-                     e
-                  );
-               }
-            }
-         });
-
-         // if translations are present return them to an object
-         if (row.translations) {
-            row.translations = JSON.parse(row.translations);
-         }
-      });
-
-      let connections = myObject.connectFields();
-      connections.forEach((connField) => {
-         let relationName = connField.relationName();
-
-         if (data.csv_packed.relations[connField.id]) {
-            let connDataParseResult = this.AB.csvToJson(
-               data.csv_packed.relations[connField.id]
-            );
-            let connData = connDataParseResult.data;
-
-            let connHash = {};
-            let connPK = connField.datasourceLink.PK();
-            connData.forEach((c) => {
-               if (!c.id) {
-                  c.id = c[connPK];
-               }
-               connHash[c._csvID] = c;
-            });
-
-            jsonData.forEach((row) => {
-               let ids = [];
-               let populatedData = [];
-               let entries = [];
-               try {
-                  // ok, we know this is a possibility, so just skip it
-                  if (row[connField.columnName] !== "") {
-                     entries = JSON.parse(row[connField.columnName]);
-                  }
-               } catch (e) {
-                  if (row[connField.columnName] == "") {
-                     // not a problem, just no data
-                  } else {
-                     // this might be a situation on the server where
-                     // row[columnName] has a value, but row[relationName] is empty.
-                     if (typeof row[relationName] == "undefined") {
-                        row[relationName] = null;
-                     }
-                     // console.error(
-                     //    "Error parsing JSON data for column: " +
-                     //       connField.columnName,
-                     //    e
-                     // );
-                  }
-               }
-               if (!Array.isArray(entries)) {
-                  entries = [entries];
-               }
-               entries.forEach((id) => {
-                  if (connHash[id]) {
-                     let connEntry = connHash[id];
-                     ids.push(connField.getRelationValue(connEntry));
-                     // Alternatively, we could remove the row[columnName] and let
-                     // normalizeData() repopulate it.
-                     populatedData.push(connEntry);
-                  }
-               });
-               if (connField.linkType() == "many") {
-                  row[connField.columnName] = ids;
-                  row[connField.relationName()] = populatedData;
-               } else {
-                  row[connField.columnName] = ids[0];
-                  row[connField.relationName()] = populatedData[0];
-               }
-            });
-
-            // now clear the ._csvID from the data
-            Object.keys(connHash).forEach((id) => {
-               delete connHash[id]._csvID;
-            });
-         }
-      });
-
-      // final pass to clear up stringified relation data
-      jsonData.forEach((row) => {
-         connections.forEach((connField) => {
-            // many connections must be an array, not "[]"
-            if (connField.linkType() == "many") {
-               let val = row[connField.columnName];
-               if (val && typeof val == "string") {
-                  row[connField.columnName] = JSON.parse(val);
-               }
-            }
-         });
-      });
-
-      let returnData = {};
-      Object.keys(data).forEach((key) => {
-         if (key != "csv_packed") {
-            returnData[key] = data[key];
-         }
-      });
-      returnData.data = jsonData;
-
-      if (returnType == "single" && Array.isArray(returnData.data)) {
-         returnData.data = returnData.data[0];
-      }
-      return returnData;
    }
 
    csvUnpackUnstringifyFields(myObject, data) {

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -923,10 +923,21 @@ module.exports = class ABModelCore {
       });
    }
 
-   csvPackGetRelations(myObject, content) {
+   csvPackMergeRelations(relations, id, connHash) {
+      relations[id] = this.AB.defaultsDeep(relations[id] || {}, connHash);
+   }
+
+   csvPackGetRelations(myObject, content, visited = new Set()) {
       let relations = {
          /* objectID: { row.id: entryJSON} */
       };
+
+      // Check for circular reference
+      if (visited.has(myObject.id)) {
+         console.warn(`Circular reference detected for object ${myObject.id}`);
+         return relations;
+      }
+      visited.add(myObject.id);
 
       // break out and compact the connected data
       let connections = myObject.connectFields();
@@ -958,34 +969,21 @@ module.exports = class ABModelCore {
          let connObject = connField.datasourceLink;
          let values = Object.values(connHash);
          if (values.length > 0) {
-            relations[connObject.id] = connHash;
+            this.csvPackMergeRelations(relations, connObject.id, connHash);
 
-            let connRelations = this.csvPackGetRelations(connObject, values);
+            let connRelations = this.csvPackGetRelations(
+               connObject,
+               values,
+               visited
+            );
 
             // merge these into my relations
             Object.keys(connRelations).forEach((id) => {
-               if (!relations[id]) {
-                  relations[id] = connRelations[id];
-               } else {
-                  Object.keys(connRelations[id]).forEach((cid) => {
-                     if (!relations[id][cid]) {
-                        relations[id][cid] = connRelations[id][cid];
-                     } else {
-                        // make sure we add any new fields from conn to relations
-                        // hopefully this is just adding a __relation value that wasn't
-                        // already there.
-                        Object.keys(connRelations[id][cid]).forEach((key) => {
-                           if (!relations[id][cid][key]) {
-                              relations[id][cid][key] =
-                                 connRelations[id][cid][key];
-                           }
-                        });
-                     }
-                  });
-               }
+               this.csvPackMergeRelations(relations, id, connRelations[id]);
             });
          }
       });
+      visited.delete(myObject.id);
       return relations;
    }
 
@@ -1075,15 +1073,23 @@ module.exports = class ABModelCore {
       //   }
       //   total_bytes:xx,
       // }
+
+      if (!data || typeof data !== "object") {
+         throw new Error("csvPack: Invalid data parameter");
+      }
+      if (data.data === undefined) {
+         throw new Error("csvPack: data.data is required");
+      }
+
       let packedData = { data: "", relations: {} };
       let myObject = this.object;
 
       let content = data.data;
-
       if (!content || (Array.isArray(content) && content.length === 0)) {
          // Return the original data if there is no content to pack
          // existing code will handle this fine.
          return data;
+      }
       this.csvPackPrepareFirstRow(myObject, content);
 
       let returnType = "array";
@@ -1123,7 +1129,11 @@ module.exports = class ABModelCore {
       }
 
       // now convert the data to CSV
-      packedData.data = this.AB.jsonToCsv(content);
+      packedData.data = await this.AB.jsonToCsvBatched(
+         content,
+         batchSize,
+         jobID
+      );
       packedData.type = returnType; // single or array
 
       let newData = {};

--- a/ABModelCore.js
+++ b/ABModelCore.js
@@ -933,7 +933,6 @@ module.exports = class ABModelCore {
       connections.forEach((connField) => {
          let connHash = {};
          let relationName = connField.relationName();
-         let connPK = connField.datasourceLink.PK();
 
          // gather all the connected data for this field
          for (let I = 0; I < content.length; I++) {
@@ -941,14 +940,16 @@ module.exports = class ABModelCore {
             if (row[relationName]) {
                if (Array.isArray(row[relationName])) {
                   row[relationName].forEach((r) => {
-                     if (!connHash[r.id]) {
-                        connHash[r.id] = r;
+                     let rval = connField.getRelationValue(r);
+                     if (!connHash[rval]) {
+                        connHash[rval] = r;
                      }
                   });
                } else {
                   let r = row[relationName];
-                  if (!connHash[r.id]) {
-                     connHash[r.id] = r;
+                  let rval = connField.getRelationValue(r);
+                  if (!connHash[rval]) {
+                     connHash[rval] = r;
                   }
                }
             }
@@ -956,34 +957,36 @@ module.exports = class ABModelCore {
 
          let connObject = connField.datasourceLink;
          let values = Object.values(connHash);
+         if (values.length > 0) {
+            relations[connObject.id] = connHash;
 
-         relations[connObject.id] = connHash;
+            let connRelations = this.csvPackGetRelations(connObject, values);
 
-         let connRelations = this.csvPackGetRelations(connObject, values);
-
-         // merge these into my relations
-         Object.keys(connRelations).forEach((id) => {
-            if (!relations[id]) {
-               relations[id] = connRelations[id];
-            } else {
-               Object.keys(connRelations[id]).forEach((cid) => {
-                  if (!relations[id][cid]) {
-                     relations[id][cid] = connRelations[id][cid];
-                  } else {
-                     // make sure we add any new fields from conn to relations
-                     // hopefully this is just adding a __relation value that wasn't
-                     // already there.
-                     Object.keys(connRelations[id][cid]).forEach((key) => {
-                        if (!relations[id][cid][key]) {
-                           relations[id][cid][key] =
-                              connRelations[id][cid][key];
-                        }
-                     });
-                  }
-               });
-            }
-         });
+            // merge these into my relations
+            Object.keys(connRelations).forEach((id) => {
+               if (!relations[id]) {
+                  relations[id] = connRelations[id];
+               } else {
+                  Object.keys(connRelations[id]).forEach((cid) => {
+                     if (!relations[id][cid]) {
+                        relations[id][cid] = connRelations[id][cid];
+                     } else {
+                        // make sure we add any new fields from conn to relations
+                        // hopefully this is just adding a __relation value that wasn't
+                        // already there.
+                        Object.keys(connRelations[id][cid]).forEach((key) => {
+                           if (!relations[id][cid][key]) {
+                              relations[id][cid][key] =
+                                 connRelations[id][cid][key];
+                           }
+                        });
+                     }
+                  });
+               }
+            });
+         }
       });
+      return relations;
    }
 
    csvPackReIndexRelations(relations) {
@@ -1010,11 +1013,13 @@ module.exports = class ABModelCore {
                hasRelationData = true;
                if (Array.isArray(row[relationName])) {
                   row[relationName].forEach((r) => {
-                     ids.push(connHash[r.id]._csvID);
+                     let rval = connField.getRelationValue(r);
+                     ids.push(connHash[rval]._csvID);
                   });
                } else {
                   let r = row[relationName];
-                  ids.push(connHash[r.id]._csvID);
+                  let rval = connField.getRelationValue(r);
+                  ids.push(connHash[rval]._csvID);
                }
             }
             // only make an update if it did have relation data
@@ -1086,7 +1091,7 @@ module.exports = class ABModelCore {
 
       // do this for the relations as well
       Object.keys(relations).forEach((id) => {
-         let relatedObj = this.AB.objectById(id);
+         let relatedObj = this.AB.objectByID(id);
          let values = Object.values(relations[id]);
          this.csvPackReEncodeRelations(relations, relatedObj, values);
          this.csvPackFinalModifications(relatedObj, values);
@@ -1435,7 +1440,7 @@ module.exports = class ABModelCore {
 
       this.csvUnpackUnstringifyFields(myObject, jsonData);
       Object.keys(relations).forEach((id) => {
-         this.csvUnpackUnstringifyFields(this.AB.objectById(id), relations[id]);
+         this.csvUnpackUnstringifyFields(this.AB.objectByID(id), relations[id]);
          // to hash by _csvID
          let hash = {};
          relations[id].forEach((c) => {
@@ -1446,7 +1451,7 @@ module.exports = class ABModelCore {
 
       // now reconnect the data
       Object.keys(relations).forEach((id) => {
-         let relatedObj = this.AB.objectById(id);
+         let relatedObj = this.AB.objectByID(id);
          let values = Object.values(relations[id]);
          this.csvUnpackReconnectRelations(relations, relatedObj, values);
       });


### PR DESCRIPTION
In response to the finance data not being able to display properly due to shallow populations of csvPacked data, this patch will now recursively scan your data and grab all relation data and make sure it is included in the packing.

[wip] implement new csvPackDeep code.

This code also depends on these PRs: [ab_platform_web#691](https://github.com/CruGlobal/ab_platform_web/pull/681), [ab_platform_service#220](https://github.com/CruGlobal/appbuilder_platform_service/pull/220),  [ab_service_appbuilder#140](https://github.com/CruGlobal/ab_service_appbuilder/pull/140)