### PR TITLE
Catch JSON.parse errors when working with corrupted translation data.

### DIFF
--- a/ABMLClassCore.js
+++ b/ABMLClassCore.js
@@ -138,7 +138,16 @@ module.exports = class ABMLClassCore extends ABEmitter {
       }
 
       if (typeof json.translations == "string") {
-         json.translations = JSON.parse(json.translations);
+         try {
+            json.translations = JSON.parse(json.translations);
+         } catch (e) {
+            console.error(`===============================================`);
+            console.error(`Error parsing translations: ${e}`);
+            console.error(`json.translations: [${json.translations}]`);
+            console.error(`obj.name: ${obj.name}`);
+            console.error(`obj.id: ${obj.id || obj.uuid}`);
+            console.error(`===============================================`);
+         }
       }
 
       var currLanguage = languageCode || this.languageDefault();


### PR DESCRIPTION
Preventing a crash when trying to translate data with invalid json data.

